### PR TITLE
feat(COIN-3): expose view_count and last_viewed_at on share links

### DIFF
--- a/backend/app/schemas/share_link.py
+++ b/backend/app/schemas/share_link.py
@@ -27,6 +27,8 @@ class ShareLinkResponse(BaseModel):
     label: str | None
     created_at: datetime
     allow_follow: bool = True
+    view_count: int = 0
+    last_viewed_at: datetime | None = None
 
     @computed_field
     @property

--- a/frontend/src/components/ShareLinkManager.tsx
+++ b/frontend/src/components/ShareLinkManager.tsx
@@ -158,6 +158,14 @@ export default function ShareLinkManager({ profiles }: Props) {
                   <span className="text-xs text-gray-500">
                     Expires: {formatExpiry(link.expires_at)}
                   </span>
+                  <span className="text-xs text-blue-400 font-medium">
+                    {link.view_count} {link.view_count === 1 ? "view" : "views"}
+                  </span>
+                  {link.last_viewed_at && (
+                    <span className="text-xs text-gray-600">
+                      Last: {new Date(link.last_viewed_at).toLocaleDateString()}
+                    </span>
+                  )}
                   <span className="text-xs text-gray-600">
                     {[
                       link.show_total_value && "total",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -62,6 +62,8 @@ export interface ShareLink {
   created_at: string;
   share_url: string;
   allow_follow: boolean;
+  view_count: number;
+  last_viewed_at: string | null;
 }
 
 export interface ShareLinkCreate {


### PR DESCRIPTION
## Summary
- Adds `view_count` and `last_viewed_at` fields to `ShareLinkResponse` Pydantic schema
- Updates frontend `ShareLink` TypeScript type with new fields
- ShareLinkManager UI now shows view count badge (e.g. "5 views") and last viewed date per link

## Test plan
- [ ] Create a share link, visit it via the public URL, check settings page shows "1 view"
- [ ] Verify `last_viewed_at` date appears after first visit
- [ ] Confirm existing links with 0 views show "0 views"

🤖 Generated with [Claude Code](https://claude.com/claude-code)