### PR TITLE
feat(COIN-4): optional Sentry error tracking via env var

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=yourdomain.com
+# Optional: set to enable Sentry error tracking (requires @sentry/nextjs package)
+NEXT_PUBLIC_SENTRY_DSN=

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,5 +1,12 @@
 'use client'
+import { useEffect } from 'react'
+import { captureError } from '@/lib/sentry'
+
 export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    captureError(error, { source: 'GlobalError' })
+  }, [error])
+
   return (
     <html>
       <body className="bg-gray-950 flex items-center justify-center min-h-screen">

--- a/frontend/src/lib/error-boundary.tsx
+++ b/frontend/src/lib/error-boundary.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Component, ReactNode } from 'react'
+import { captureError } from './sentry'
 
 interface Props { children: ReactNode; fallback?: ReactNode }
 interface State { hasError: boolean }
@@ -9,7 +10,7 @@ export class ErrorBoundary extends Component<Props, State> {
   static getDerivedStateFromError() { return { hasError: true } }
   componentDidCatch(error: Error) {
     console.error('[ErrorBoundary]', error)
-    // Sentry.captureException(error) when Sentry DSN configured
+    captureError(error, { source: 'ErrorBoundary' })
   }
   render() {
     if (this.state.hasError) return this.props.fallback ?? <div className="text-red-400 p-4">Something went wrong</div>

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -1,0 +1,43 @@
+/**
+ * Optional Sentry error tracking — only active when NEXT_PUBLIC_SENTRY_DSN is set.
+ * Uses dynamic import to avoid bundle bloat when Sentry is not configured.
+ */
+
+let _initialized = false;
+
+async function initSentry() {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn || _initialized || typeof window === 'undefined') return;
+  try {
+    const Sentry = await import('@sentry/nextjs');
+    Sentry.init({
+      dsn,
+      tracesSampleRate: 0.1,
+      environment: process.env.NODE_ENV,
+    });
+    _initialized = true;
+  } catch {
+    // Sentry package not installed — silently skip
+  }
+}
+
+export async function captureError(error: Error, context?: Record<string, unknown>) {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn || typeof window === 'undefined') return;
+  try {
+    await initSentry();
+    const Sentry = await import('@sentry/nextjs');
+    Sentry.withScope((scope) => {
+      if (context) {
+        Object.entries(context).forEach(([key, value]) => {
+          scope.setExtra(key, value);
+        });
+      }
+      Sentry.captureException(error);
+    });
+  } catch {
+    // Sentry unavailable — silently skip
+  }
+}
+
+export { initSentry };


### PR DESCRIPTION
## Summary
- Adds `frontend/src/lib/sentry.ts` — a thin wrapper that dynamically imports `@sentry/nextjs` only when `NEXT_PUBLIC_SENTRY_DSN` is configured
- Zero bundle impact when DSN is not set (dynamic import + silent catch)
- Wires `captureError` into `ErrorBoundary.componentDidCatch` and `GlobalError` via `useEffect`
- Documents `NEXT_PUBLIC_SENTRY_DSN` env var in `.env.example`

## Test plan
- [ ] With `NEXT_PUBLIC_SENTRY_DSN` unset: app builds and runs normally, no errors
- [ ] With DSN set and `@sentry/nextjs` installed: uncaught errors appear in Sentry dashboard
- [ ] Trigger error boundary and verify Sentry call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)