### PR TITLE
feat(COIN-5): tier upgrade prompt and admin stats improvements

### DIFF
--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -29,13 +29,21 @@ async def get_stats(
         select(func.count(ShareLink.id)).where(ShareLink.is_active == True)  # noqa: E712
     )
 
+    exchange_key_count = await db.scalar(select(func.count(ExchangeKey.id)))
+
     exchange_dist_rows = await db.execute(
         select(ExchangeKey.exchange, func.count(ExchangeKey.id)).group_by(ExchangeKey.exchange)
+    )
+
+    tier_dist_rows = await db.execute(
+        select(User.tier, func.count(User.id)).group_by(User.tier)
     )
 
     return {
         "users": user_count,
         "profiles": profile_count,
+        "exchange_keys": exchange_key_count,
         "active_share_links": share_count,
         "exchanges": {row[0]: row[1] for row in exchange_dist_rows},
+        "tiers": {row[0]: row[1] for row in tier_dist_rows},
     }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import AddKeyModal from "@/components/AddKeyModal";
 import ShareLinkManager from "@/components/ShareLinkManager";
 import { Navigation } from "@/components/Navigation";
 import { ConfirmModal } from "@/components/ConfirmModal";
+import { UpgradeBanner } from "@/components/UpgradeBanner";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -21,6 +22,7 @@ export default function SettingsPage() {
     message: string;
     onConfirm: () => void;
   } | null>(null);
+  const [tierLimitMessage, setTierLimitMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem('token')
@@ -81,6 +83,13 @@ export default function SettingsPage() {
           Add Profile
         </button>
       </div>
+
+      {/* Tier limit banner */}
+      {tierLimitMessage && (
+        <div className="mb-6">
+          <UpgradeBanner message={tierLimitMessage} />
+        </div>
+      )}
 
       {/* Profiles list */}
       <div className="space-y-4">
@@ -154,6 +163,7 @@ export default function SettingsPage() {
         <AddProfileModal
           onClose={() => setShowAddProfile(false)}
           onCreated={loadProfiles}
+          onTierLimit={(msg) => setTierLimitMessage(msg)}
         />
       )}
       {addKeyForProfile !== null && (

--- a/frontend/src/components/AddProfileModal.tsx
+++ b/frontend/src/components/AddProfileModal.tsx
@@ -8,9 +8,10 @@ import { useFocusTrap } from "@/hooks/useFocusTrap";
 interface Props {
   onClose: () => void;
   onCreated: () => void;
+  onTierLimit?: (message: string) => void;
 }
 
-export default function AddProfileModal({ onClose, onCreated }: Props) {
+export default function AddProfileModal({ onClose, onCreated, onTierLimit }: Props) {
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,7 +36,13 @@ export default function AddProfileModal({ onClose, onCreated }: Props) {
       onCreated();
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create profile");
+      const msg = err instanceof Error ? err.message : "Failed to create profile";
+      if (msg.toLowerCase().includes("free tier") || msg.toLowerCase().includes("upgrade")) {
+        onTierLimit?.(msg);
+        onClose();
+      } else {
+        setError(msg);
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/UpgradeBanner.tsx
+++ b/frontend/src/components/UpgradeBanner.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+
+interface Props {
+  message?: string;
+}
+
+/**
+ * Shown when the backend returns a 403 tier-limit error.
+ * Prompts the user to upgrade to Premium.
+ */
+export function UpgradeBanner({ message }: Props) {
+  return (
+    <div
+      role="alert"
+      className="flex items-center justify-between gap-4 rounded-xl border border-amber-700/60 bg-amber-900/20 px-5 py-4"
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-amber-400 text-lg" aria-hidden="true">⚡</span>
+        <div>
+          <p className="text-sm font-medium text-amber-300">
+            {message ?? "You've reached your free tier limit."}
+          </p>
+          <p className="text-xs text-amber-500 mt-0.5">
+            Upgrade to Premium for unlimited profiles and exchanges.
+          </p>
+        </div>
+      </div>
+      <Link
+        href="/pricing"
+        className="shrink-0 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-gray-900 text-sm font-semibold rounded-lg transition-colors"
+      >
+        Upgrade
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `UpgradeBanner` component: amber alert shown when free tier limit is reached, links to `/pricing`
- `AddProfileModal` now accepts `onTierLimit` callback — 403 tier errors are propagated to the settings page instead of shown inline
- Settings page displays `UpgradeBanner` when tier limit is hit, dismissing the modal cleanly
- Backend `/admin/stats` endpoint now includes `exchange_keys` count and `tiers` breakdown (free/premium/admin distribution)

## Test plan
- [ ] Free-tier user tries to add 2nd profile → UpgradeBanner appears with upgrade CTA
- [ ] Clicking "Upgrade" navigates to `/pricing`
- [ ] Admin stats endpoint returns `exchange_keys` and `tiers` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)