### PR TITLE
fix(keys): enforce exchange key limit for free-tier users

### DIFF
--- a/backend/app/api/v1/keys.py
+++ b/backend/app/api/v1/keys.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
+from app.core.limits import check_exchange_limit
 from app.core.logging import logger
 from app.core.security import encrypt, get_current_user
 from app.exchanges.factory import SUPPORTED_EXCHANGES, get_adapter
@@ -52,6 +53,17 @@ async def add_key(
     current_user: User = Depends(get_current_user),
 ):
     await _get_owned_profile(profile_id, db, current_user)
+
+    # Enforce tier-based exchange key limit
+    existing_keys_result = await db.execute(
+        select(ExchangeKey).where(ExchangeKey.profile_id == profile_id)
+    )
+    existing_count = len(existing_keys_result.scalars().all())
+    if not check_exchange_limit(current_user, existing_count):
+        raise HTTPException(
+            status_code=403,
+            detail="tier_limit: You have reached the exchange key limit for your current plan. Upgrade to Premium for unlimited keys.",
+        )
 
     if payload.exchange.lower() not in SUPPORTED_EXCHANGES:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Closes #21
- Imports and calls `check_exchange_limit()` in `add_key()` before inserting a new key
- Returns HTTP 403 with `tier_limit:` detail when free user exceeds the exchange cap
- Premium users are unaffected (limit = -1 = unlimited)

## Root Cause
`check_exchange_limit()` was defined in `backend/app/core/limits.py` but never imported or called from the keys endpoint. Free users could add any number of exchange keys.

## Changes
- `backend/app/api/v1/keys.py`: add import, count existing keys per profile, call limit check

## Test Plan
- [ ] Free user with 2 existing keys gets 403 on a 3rd add attempt
- [ ] Free user with 1 existing key can add a 2nd key
- [ ] Premium user with 50+ keys can still add more
- [ ] `test_limits.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)