### PR TITLE
feat(analytics): fire shareLinkViewed event on public share page load

### DIFF
--- a/frontend/src/app/share/[token]/page.tsx
+++ b/frontend/src/app/share/[token]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { SharedPortfolioView } from "@/lib/types";
 import FollowButton from "@/components/FollowButton";
+import ShareViewTracker from "@/components/ShareViewTracker";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
@@ -71,6 +72,7 @@ export default async function SharePage({
 
   return (
     <div className="min-h-screen bg-gray-950 text-white">
+      <ShareViewTracker token={token} />
       {/* Header */}
       <header className="border-b border-gray-800 px-6 py-4">
         <div className="max-w-3xl mx-auto flex items-center justify-between">

--- a/frontend/src/components/ShareViewTracker.tsx
+++ b/frontend/src/components/ShareViewTracker.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { events } from "@/lib/analytics";
+
+/**
+ * Fires the shareLinkViewed analytics event once when the public share page mounts.
+ * Must be a client component because analytics relies on browser APIs (window.plausible).
+ */
+export default function ShareViewTracker({ token }: { token: string }) {
+  useEffect(() => {
+    events.shareLinkViewed(token);
+  }, [token]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Closes #22
- New `ShareViewTracker` client component fires `events.shareLinkViewed(token)` on mount
- Included in the `SharePage` server component via Next.js App Router client boundary pattern

## Root Cause
`events.shareLinkViewed()` was defined in `analytics.ts` but never called anywhere. The share page was a pure server component that cannot use browser APIs directly.

## Changes
- `frontend/src/components/ShareViewTracker.tsx` — new client component (renders null, fires event)
- `frontend/src/app/share/[token]/page.tsx` — adds `<ShareViewTracker token={token} />` after data is confirmed valid

## Test Plan
- [ ] Open a valid share link in browser with Plausible configured
- [ ] Verify `Share Link Viewed` event appears in Plausible dashboard
- [ ] No SSR errors (component renders null server-side, fires event client-side)
- [ ] No lint errors (`pnpm lint` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)