### PR TITLE
feat(analytics): track UpgradeBanner impressions and upgrade clicks

### DIFF
--- a/frontend/src/components/UpgradeBanner.tsx
+++ b/frontend/src/components/UpgradeBanner.tsx
@@ -1,16 +1,25 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/analytics";
 
 interface Props {
   message?: string;
+  /** Attribution source shown in analytics. Defaults to 'settings'. */
+  source?: string;
 }
 
 /**
  * Shown when the backend returns a 403 tier-limit error.
  * Prompts the user to upgrade to Premium.
+ * Fires Plausible events on impression and upgrade-click.
  */
-export function UpgradeBanner({ message }: Props) {
+export function UpgradeBanner({ message, source = "settings" }: Props) {
+  useEffect(() => {
+    trackEvent("Upgrade Banner Shown", { source });
+  }, [source]);
+
   return (
     <div
       role="alert"
@@ -29,6 +38,7 @@ export function UpgradeBanner({ message }: Props) {
       </div>
       <Link
         href="/pricing"
+        onClick={() => trackEvent("Upgrade Clicked", { source })}
         className="shrink-0 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-gray-900 text-sm font-semibold rounded-lg transition-colors"
       >
         Upgrade


### PR DESCRIPTION
## Summary
- Closes #23
- `UpgradeBanner` now fires `'Upgrade Banner Shown'` on mount (impression)
- Fires `'Upgrade Clicked'` when the Upgrade link is clicked
- Accepts optional `source` prop (default `'settings'`) for attribution across future placements

## Root Cause
The conversion funnel was invisible — no data on how many users see the upgrade prompt vs. click through to pricing. Both events are no-ops when Plausible is not configured.

## Changes
- `frontend/src/components/UpgradeBanner.tsx`: adds `useEffect` impression tracker, onClick click tracker, and `source` prop

## Test Plan
- [ ] Trigger a free-tier limit (add 2nd profile or 3rd exchange key)
- [ ] Verify `Upgrade Banner Shown` event fires in Plausible
- [ ] Click the Upgrade button; verify `Upgrade Clicked` event fires
- [ ] `pnpm lint` passes
- [ ] No regression in existing settings page behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)