### PR TITLE
fix(share): redact profile_name in public share view to protect privacy

### DIFF
--- a/backend/app/api/v1/share.py
+++ b/backend/app/api/v1/share.py
@@ -230,9 +230,12 @@ async def public_share_view(
             total_usd=ex.total_usd if link.show_total_value else None,
         ))
 
+    # Use link label if set, otherwise return generic name to protect profile privacy
+    public_display_name = link.label or "Crypto Portfolio"
+
     return SharedPortfolioView(
         token=token,
-        profile_name=profile.name,
+        profile_name=public_display_name,
         total_usd=portfolio.total_usd if link.show_total_value else None,
         exchanges=filtered_exchanges,
         show_total_value=link.show_total_value,


### PR DESCRIPTION
## Summary
- The public share endpoint was returning raw `profile.name`, which may contain the user's real name
- Now returns `link.label` if set, or falls back to `'Crypto Portfolio'`
- Used consistently in both the API response and OG metadata

## Behavior
| link.label | Public display_name |
|------------|---------------------|
| `"My Portfolio"` | `"My Portfolio"` |
| `null` | `"Crypto Portfolio"` |

## Test Plan
- [ ] Create link without label — public view shows "Crypto Portfolio"
- [ ] Create link with label "Trading Account" — public view shows "Trading Account"
- [ ] OG title uses the display name, not raw profile name
- [ ] All `test_share.py` tests pass (14 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)