### PR TITLE
fix(auth): migrate OAuth CSRF state storage from in-memory dict to Redis

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -25,18 +25,12 @@ GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
 SCOPES = "openid email profile"
 
-# In-memory store for OAuth state tokens (short-lived, CSRF protection)
-_oauth_states: dict[str, float] = {}
 _STATE_TTL_SECONDS = 600  # 10 minutes
+_OAUTH_STATE_PREFIX = "oauth_state:"
 
 
-def _cleanup_expired_states() -> None:
-    """Remove expired state tokens."""
-    import time
-    now = time.time()
-    expired = [k for k, v in _oauth_states.items() if now - v > _STATE_TTL_SECONDS]
-    for k in expired:
-        _oauth_states.pop(k, None)
+def _state_key(state: str) -> str:
+    return f"{_OAUTH_STATE_PREFIX}{state}"
 
 
 def _redirect_uri(request: Request) -> str:
@@ -51,12 +45,10 @@ def _redirect_uri(request: Request) -> str:
 @router.get("/google")
 async def google_login(request: Request):
     """Redirect user to Google OAuth consent screen."""
-    import time
-
-    _cleanup_expired_states()
+    redis = request.app.state.redis
 
     state = secrets.token_urlsafe(32)
-    _oauth_states[state] = time.time()
+    await redis.set(_state_key(state), "1", ex=_STATE_TTL_SECONDS)
 
     redirect_uri = _redirect_uri(request)
     params = (
@@ -83,12 +75,13 @@ async def google_callback(
     if error or not code:
         raise HTTPException(status_code=401, detail=f"OAuth error: {error or 'missing code'}")
 
-    # Validate CSRF state parameter
-    import time
-    if not state or state not in _oauth_states:
+    # Validate CSRF state parameter — use Redis for multi-replica safety
+    if not state:
         raise HTTPException(status_code=403, detail="Invalid OAuth state — possible CSRF attack")
-    if time.time() - _oauth_states.pop(state) > _STATE_TTL_SECONDS:
-        raise HTTPException(status_code=403, detail="OAuth state expired, please try again")
+    redis = request.app.state.redis
+    deleted = await redis.delete(_state_key(state))
+    if not deleted:
+        raise HTTPException(status_code=403, detail="Invalid OAuth state — possible CSRF attack")
 
     redirect_uri = _redirect_uri(request)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,7 +1,6 @@
 """Tests for api/v1/auth.py — OAuth flow and token refresh."""
 
 import os
-import time
 
 os.environ.setdefault("ENCRYPTION_KEY", "dGVzdC1lbmNyeXB0aW9uLWtleS0zMi1ieXRlc3h4")
 os.environ.setdefault("JWT_SECRET", "test-jwt-secret-for-unit-tests-only")
@@ -13,18 +12,24 @@ from fastapi import HTTPException
 
 from app.api.v1.auth import (
     RefreshRequest,
-    _cleanup_expired_states,
-    _oauth_states,
     google_callback,
     refresh_access_token,
 )
 from app.core.security import create_access_token, create_refresh_token
 
 
+def _make_request_with_redis(redis_mock: AsyncMock) -> MagicMock:
+    """Build a mock Request whose app.state.redis is the given mock."""
+    request = MagicMock()
+    request.app.state.redis = redis_mock
+    return request
+
+
 class TestGoogleCallback:
     @pytest.mark.asyncio
     async def test_rejects_missing_code(self):
-        request = MagicMock()
+        redis = AsyncMock()
+        request = _make_request_with_redis(redis)
         db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc:
@@ -33,7 +38,8 @@ class TestGoogleCallback:
 
     @pytest.mark.asyncio
     async def test_rejects_oauth_error(self):
-        request = MagicMock()
+        redis = AsyncMock()
+        request = _make_request_with_redis(redis)
         db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc:
@@ -44,8 +50,25 @@ class TestGoogleCallback:
         assert "access_denied" in str(exc.value.detail)
 
     @pytest.mark.asyncio
+    async def test_rejects_none_state(self):
+        """state=None raises 403 before even touching Redis."""
+        redis = AsyncMock()
+        request = _make_request_with_redis(redis)
+        db = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await google_callback(
+                request=request, code="authcode123", error=None, state=None, db=db
+            )
+        assert exc.value.status_code == 403
+        assert "CSRF" in exc.value.detail
+
+    @pytest.mark.asyncio
     async def test_rejects_invalid_state(self):
-        request = MagicMock()
+        """Redis returns 0 (key not found) → 403 CSRF."""
+        redis = AsyncMock()
+        redis.delete = AsyncMock(return_value=0)  # key not in Redis
+        request = _make_request_with_redis(redis)
         db = AsyncMock()
 
         with pytest.raises(HTTPException) as exc:
@@ -54,21 +77,6 @@ class TestGoogleCallback:
             )
         assert exc.value.status_code == 403
         assert "CSRF" in exc.value.detail
-
-    @pytest.mark.asyncio
-    async def test_rejects_expired_state(self):
-        state = "test-expired-state"
-        _oauth_states[state] = time.time() - 700  # expired (>600s)
-
-        request = MagicMock()
-        db = AsyncMock()
-
-        with pytest.raises(HTTPException) as exc:
-            await google_callback(
-                request=request, code="authcode123", error=None, state=state, db=db
-            )
-        assert exc.value.status_code == 403
-        assert "expired" in exc.value.detail.lower()
 
 
 class TestRefreshAccessToken:
@@ -97,17 +105,3 @@ class TestRefreshAccessToken:
         with pytest.raises(HTTPException) as exc:
             await refresh_access_token(body)
         assert exc.value.status_code == 401
-
-
-class TestCleanupExpiredStates:
-    def test_removes_expired_states(self):
-        _oauth_states["old"] = time.time() - 700
-        _oauth_states["fresh"] = time.time()
-
-        _cleanup_expired_states()
-
-        assert "old" not in _oauth_states
-        assert "fresh" in _oauth_states
-
-        # Cleanup
-        _oauth_states.pop("fresh", None)


### PR DESCRIPTION
## Summary
- Closes #29
- Removes module-level `_oauth_states` dict and `_cleanup_expired_states()` helper
- Stores OAuth CSRF state tokens in Redis as `oauth_state:{state}` with 600s TTL
- Atomic `redis.delete()` returns 1 (valid) or 0 (invalid/expired) — no race condition
- Works across all replicas on Railway multi-instance deployments

## Root Cause
`_oauth_states: dict[str, float] = {}` lives in each process's memory. On a multi-replica Railway deployment, replica A stores the state but the callback may hit replica B, which has an empty dict → 403 CSRF error for legitimate users.

## Changes
- `backend/app/api/v1/auth.py`: Redis-based state store with TTL
- `backend/tests/test_auth.py`: updated to mock `request.app.state.redis`; removed `TestCleanupExpiredStates` (obsolete)

## Test Plan
- [ ] All 7 `test_auth.py` tests pass
- [ ] OAuth login flow works end-to-end (requires running instance with Redis)
- [ ] Invalid state returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)