### PR TITLE
security(sentry): add beforeSend PII scrubbing to strip tokens from URLs

### DIFF
--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -5,6 +5,30 @@
 
 let _initialized = false;
 
+/**
+ * Scrub PII from Sentry events before sending.
+ * - Strips query strings (removes ?token=... JWT leaks from /auth/callback)
+ * - Redacts share link tokens in URL paths (/share/<token> → /share/[token])
+ */
+function _scrubEvent(event: Record<string, unknown>): Record<string, unknown> {
+  const req = event.request as Record<string, unknown> | undefined;
+  if (req?.url && typeof req.url === 'string') {
+    try {
+      const url = new URL(req.url);
+      // Strip all query parameters (may contain JWTs, tokens)
+      url.search = '';
+      // Redact share link tokens: /share/<alphanumeric> → /share/[token]
+      url.pathname = url.pathname.replace(/\/share\/[A-Za-z0-9_-]{20,}/, '/share/[token]');
+      req.url = url.toString();
+    } catch {
+      // If URL parsing fails, remove it entirely rather than send raw
+      delete req.url;
+    }
+    event.request = req;
+  }
+  return event;
+}
+
 async function initSentry() {
   const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
   if (!dsn || _initialized || typeof window === 'undefined') return;
@@ -14,6 +38,9 @@ async function initSentry() {
       dsn,
       tracesSampleRate: 0.1,
       environment: process.env.NODE_ENV,
+      beforeSend(event) {
+        return _scrubEvent(event as unknown as Record<string, unknown>) as typeof event;
+      },
     });
     _initialized = true;
   } catch {


### PR DESCRIPTION
## Summary
- Closes #31
- Adds `_scrubEvent()` helper with `beforeSend` hook to Sentry initialization
- Strips entire query string from event request URLs (removes `?token=<jwt>` leaks)
- Redacts share link tokens in paths: `/share/<token>` → `/share/[token]`

## Root Cause
Sentry was initialized without `beforeSend`, so it sent raw URLs to Sentry's servers including JWTs from the OAuth callback (`?token=<jwt>&refresh_token=<rt>`) and share link tokens from public pages.

## Changes
- `frontend/src/lib/sentry.ts`: added `_scrubEvent()`, wired into `beforeSend`

## Test Plan
- [ ] Analytics tests pass: `vitest run src/__tests__/analytics.test.ts`
- [ ] `pnpm lint` passes
- [ ] Trigger Sentry event in dev; verify URL has no query string and share paths are redacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)