### PR TITLE
test(keys): add coverage for exchange key tier limit 403 response

### DIFF
--- a/backend/tests/test_keys_api.py
+++ b/backend/tests/test_keys_api.py
@@ -26,6 +26,19 @@ def _make_profile(profile_id: int = 1, owner_id: int = 1):
     return profile
 
 
+def _setup_db_execute(db: AsyncMock, existing_key_count: int = 0) -> None:
+    """Configure db.execute to return a mock result with the given number of existing keys."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [MagicMock()] * existing_key_count
+    db.execute = AsyncMock(return_value=mock_result)
+
+
+def _make_free_user(user_id: int = 1) -> MagicMock:
+    user = _make_user(user_id)
+    user.tier = "free"
+    return user
+
+
 class TestGetOwnedProfile:
     @pytest.mark.asyncio
     async def test_returns_profile_for_owner(self):
@@ -62,12 +75,15 @@ class TestAddKey:
         db = AsyncMock()
         profile = _make_profile(profile_id=1, owner_id=1)
         db.get = AsyncMock(return_value=profile)
+        _setup_db_execute(db, existing_key_count=0)
 
         payload = MagicMock()
         payload.exchange = "unsupported_exchange"
         payload.api_key = "test_key_12345678"
         payload.api_secret = "test_secret_12345678"
 
+        user = _make_user(1)
+        user.tier = "free"
         request = MagicMock()
 
         with pytest.raises(HTTPException) as exc:
@@ -76,7 +92,7 @@ class TestAddKey:
                 profile_id=1,
                 payload=payload,
                 db=db,
-                current_user=_make_user(1),
+                current_user=user,
             )
         assert exc.value.status_code == 400
         assert "Unsupported exchange" in exc.value.detail
@@ -86,6 +102,10 @@ class TestAddKey:
         db = AsyncMock()
         profile = _make_profile(profile_id=1, owner_id=1)
         db.get = AsyncMock(return_value=profile)
+        _setup_db_execute(db, existing_key_count=0)
+
+        user = _make_user(1)
+        user.tier = "free"
 
         payload = MagicMock()
         payload.exchange = "binance"
@@ -105,7 +125,7 @@ class TestAddKey:
                     profile_id=1,
                     payload=payload,
                     db=db,
-                    current_user=_make_user(1),
+                    current_user=user,
                 )
         assert exc.value.status_code == 400
         assert "validation failed" in exc.value.detail.lower()
@@ -115,6 +135,10 @@ class TestAddKey:
         db = AsyncMock()
         profile = _make_profile(profile_id=1, owner_id=1)
         db.get = AsyncMock(return_value=profile)
+        _setup_db_execute(db, existing_key_count=0)
+
+        user = _make_user(1)
+        user.tier = "free"
 
         payload = MagicMock()
         payload.exchange = "binance"
@@ -136,7 +160,7 @@ class TestAddKey:
                     profile_id=1,
                     payload=payload,
                     db=db,
-                    current_user=_make_user(1),
+                    current_user=user,
                 )
         assert exc.value.status_code == 400
         assert "Write permissions" in exc.value.detail
@@ -146,6 +170,10 @@ class TestAddKey:
         db = AsyncMock()
         profile = _make_profile(profile_id=1, owner_id=1)
         db.get = AsyncMock(return_value=profile)
+        _setup_db_execute(db, existing_key_count=0)
+
+        user = _make_user(1)
+        user.tier = "free"
 
         mock_key_obj = MagicMock()
         mock_key_obj.id = 10
@@ -166,20 +194,100 @@ class TestAddKey:
         with patch("app.api.v1.keys.get_adapter", return_value=mock_adapter):
             with patch("app.api.v1.keys.encrypt") as mock_encrypt:
                 mock_encrypt.side_effect = lambda x: f"encrypted_{x}"
-                with patch("app.api.v1.keys.ExchangeKey") as mock_exchange_key_cls:
-                    mock_exchange_key_cls.return_value = mock_key_obj
-                    db.refresh = AsyncMock()
-                    await add_key(
-                        request=request,
-                        profile_id=1,
-                        payload=payload,
-                        db=db,
-                        current_user=_make_user(1),
-                    )
+                # Patch select to avoid SQLAlchemy validation when ExchangeKey is mocked
+                with patch("app.api.v1.keys.select", return_value=MagicMock()):
+                    with patch("app.api.v1.keys.ExchangeKey") as mock_exchange_key_cls:
+                        mock_exchange_key_cls.return_value = mock_key_obj
+                        db.refresh = AsyncMock()
+                        await add_key(
+                            request=request,
+                            profile_id=1,
+                            payload=payload,
+                            db=db,
+                            current_user=user,
+                        )
 
                 # Verify encrypt was called with plaintext values
                 mock_encrypt.assert_any_call("plaintext_api_key_123")
                 mock_encrypt.assert_any_call("plaintext_secret_456")
+
+
+    @pytest.mark.asyncio
+    async def test_rejects_free_user_over_exchange_limit(self):
+        """Free users cannot add more exchange keys than TIER_LIMITS allows (max 2)."""
+        db = AsyncMock()
+        profile = _make_profile(profile_id=1, owner_id=1)
+        db.get = AsyncMock(return_value=profile)
+
+        # Simulate 2 existing keys (at limit for free tier)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [MagicMock(), MagicMock()]
+        db.execute = AsyncMock(return_value=mock_result)
+
+        # Free user (default tier)
+        user = _make_user(1)
+        user.tier = "free"
+
+        payload = MagicMock()
+        payload.exchange = "binance"
+
+        request = MagicMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await add_key(
+                request=request,
+                profile_id=1,
+                payload=payload,
+                db=db,
+                current_user=user,
+            )
+        assert exc.value.status_code == 403
+        assert "tier_limit" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_allows_premium_user_beyond_exchange_limit(self):
+        """Premium users are not subject to the exchange key cap."""
+        db = AsyncMock()
+        profile = _make_profile(profile_id=1, owner_id=1)
+        db.get = AsyncMock(return_value=profile)
+
+        # Simulate 5 existing keys (far beyond free tier limit)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [MagicMock()] * 5
+        db.execute = AsyncMock(return_value=mock_result)
+
+        premium_user = _make_user(1)
+        premium_user.tier = "premium"
+
+        payload = MagicMock()
+        payload.exchange = "binance"
+        payload.api_key = "test_key_12345678"
+        payload.api_secret = "test_secret_12345678"
+
+        request = MagicMock()
+        request.app.state.http_client = None
+
+        mock_adapter = AsyncMock()
+        mock_adapter.validate_key = AsyncMock(return_value=True)
+
+        mock_key_obj = MagicMock()
+        mock_key_obj.id = 10
+        mock_key_obj.profile_id = 1
+        mock_key_obj.exchange = "binance"
+
+        with patch("app.api.v1.keys.get_adapter", return_value=mock_adapter):
+            with patch("app.api.v1.keys.encrypt", side_effect=lambda x: f"enc_{x}"):
+                with patch("app.api.v1.keys.select", return_value=MagicMock()):
+                    with patch("app.api.v1.keys.ExchangeKey", return_value=mock_key_obj):
+                        db.refresh = AsyncMock()
+                        result = await add_key(
+                            request=request,
+                            profile_id=1,
+                            payload=payload,
+                            db=db,
+                            current_user=premium_user,
+                        )
+        assert result is not None
 
 
 class TestDeleteKey:


### PR DESCRIPTION
## Summary
- Adds 2 new tests for the tier limit check introduced in PR #25
- Updates existing `TestAddKey` tests to mock `db.execute` (required after `add_key` now counts existing keys)
- Adds `_setup_db_execute()` helper for clean test setup

## New Tests
- `test_rejects_free_user_over_exchange_limit`: free user with 2 existing keys gets 403 with `tier_limit` detail
- `test_allows_premium_user_beyond_exchange_limit`: premium user with 5 existing keys can still add more

## Test Plan
- [ ] `pytest tests/test_keys_api.py` — all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)