### PR TITLE
security(crypto): wire MultiFernet for key rotation (ENCRYPTION_KEYS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ REDIS_URL=redis://redis:6379/0
 # ─── Encryption ─────────────────────────────────────────────
 # Generate: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ENCRYPTION_KEY=your-fernet-key-here
+# Optional: comma-separated past keys for rotation. Old ciphertexts decrypt via
+# any listed key; new ciphertexts always use ENCRYPTION_KEY (the primary).
+# Rotation flow:
+#   1) Generate a new Fernet key.
+#   2) Move the current ENCRYPTION_KEY value to ENCRYPTION_KEYS (append, CSV).
+#   3) Set ENCRYPTION_KEY to the new key. Restart.
+#   4) Re-encrypt records on the next write; remove the rotated-out key from
+#      ENCRYPTION_KEYS once you have re-encrypted everything.
+# ENCRYPTION_KEYS=oldkey1=,oldkey2=
 
 # ─── JWT ────────────────────────────────────────────────────
 # Generate: openssl rand -hex 32

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,7 +14,12 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/0"
 
     # Security
-    ENCRYPTION_KEY: str  # Fernet key — required
+    ENCRYPTION_KEY: str  # Fernet key — required (used as primary if ENCRYPTION_KEYS unset)
+    # Optional CSV of additional past Fernet keys for rotation. The first non-empty
+    # entry in the merged list (ENCRYPTION_KEY first, then ENCRYPTION_KEYS) is used
+    # to encrypt new ciphertexts; all entries are tried for decryption.
+    # Example: ENCRYPTION_KEYS="oldkey1=,oldkey2="
+    ENCRYPTION_KEYS: str = ""
 
     # JWT
     JWT_SECRET: str  # required

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -17,33 +17,69 @@ from app.core.config import settings
 from app.core.database import get_db
 
 # ── Fernet encryption ──────────────────────────────────────────────────────────
+#
+# Encryption is always performed via MultiFernet so rotation works without code
+# changes. When only ENCRYPTION_KEY is set we wrap a single Fernet in MultiFernet
+# (no behavioral difference vs. plain Fernet). When ENCRYPTION_KEYS is set as a
+# comma-separated list of additional past keys, those are appended after the
+# primary key — the primary is always used to encrypt; all keys are tried for
+# decryption (Fernet's MultiFernet semantics).
 
-_fernet: Fernet | None = None
+_fernet: MultiFernet | None = None
 
 
-def _get_fernet() -> Fernet:
+def _build_key_list() -> list[str]:
+    """Merge ENCRYPTION_KEY (primary) with ENCRYPTION_KEYS (CSV of past keys).
+
+    The primary key always comes first, so MultiFernet uses it to encrypt new
+    ciphertexts. Past keys are tried for decryption only. Empty/whitespace
+    entries in ENCRYPTION_KEYS are ignored. Duplicates of the primary key are
+    de-duplicated to avoid wasted decrypt attempts.
+    """
+    keys: list[str] = [settings.ENCRYPTION_KEY]
+    extra = [k.strip() for k in settings.ENCRYPTION_KEYS.split(",") if k.strip()]
+    for k in extra:
+        if k not in keys:
+            keys.append(k)
+    return keys
+
+
+def _get_fernet() -> MultiFernet:
     global _fernet
     if _fernet is None:
-        _fernet = Fernet(settings.ENCRYPTION_KEY.encode())
+        _fernet = get_multi_fernet(_build_key_list())
     return _fernet
 
 
+def reset_fernet_cache() -> None:
+    """Clear the cached MultiFernet — used by tests after mutating settings.
+
+    Production code never needs this; the cache is built lazily on first use.
+    """
+    global _fernet
+    _fernet = None
+
+
 def encrypt(plaintext: str) -> str:
-    """Encrypt a plaintext string. Returns a base64 Fernet token."""
+    """Encrypt a plaintext string with the primary key. Returns a base64 Fernet token."""
     f = _get_fernet()
     return f.encrypt(plaintext.encode()).decode()
 
 
 def decrypt(token: str) -> str:
-    """Decrypt a Fernet token. Returns plaintext string."""
+    """Decrypt a Fernet token using any configured key. Returns plaintext string."""
     f = _get_fernet()
     return f.decrypt(token.encode()).decode()
 
 
 def get_multi_fernet(keys: list[str]) -> MultiFernet:
-    """Support multiple encryption keys for rotation.
-    First key is used for encryption, all keys tried for decryption.
+    """Build a MultiFernet from one or more keys.
+
+    The first key is used for encryption; all keys are tried for decryption.
+    Used internally by `_get_fernet()` and exposed for ad-hoc rotation tooling.
     """
+    if not keys:
+        raise ValueError("get_multi_fernet requires at least one key")
     fernets = [Fernet(k.encode()) for k in keys]
     return MultiFernet(fernets)
 

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -34,6 +34,7 @@ from app.core.security import (
     encrypt,
     get_current_user,
     get_multi_fernet,
+    reset_fernet_cache,
 )
 
 # ── Encryption ────────────────────────────────────────────────────────────────
@@ -72,6 +73,54 @@ class TestEncryption:
 
         new_ciphertext = multi.encrypt(b"new-secret").decode()
         assert multi.decrypt(new_ciphertext.encode()) == b"new-secret"
+
+    def test_get_multi_fernet_rejects_empty_list(self):
+        with pytest.raises(ValueError):
+            get_multi_fernet([])
+
+    def test_encrypt_decrypt_supports_rotation_via_settings(self):
+        """End-to-end rotation: encrypt with old key, rotate config, decrypt still works."""
+        from cryptography.fernet import Fernet
+
+        old_key = Fernet.generate_key().decode()
+        new_key = Fernet.generate_key().decode()
+
+        # Step 1: configure only old key, encrypt a secret
+        settings.ENCRYPTION_KEY = old_key
+        settings.ENCRYPTION_KEYS = ""
+        reset_fernet_cache()
+        ct = encrypt("rotation-payload")
+
+        # Step 2: rotate — new key becomes primary, old key kept for decrypt
+        settings.ENCRYPTION_KEY = new_key
+        settings.ENCRYPTION_KEYS = old_key
+        reset_fernet_cache()
+
+        # Old ciphertext still decrypts (via fallback key)
+        assert decrypt(ct) == "rotation-payload"
+
+        # New encryptions use the new primary key
+        new_ct = encrypt("post-rotation")
+        assert decrypt(new_ct) == "post-rotation"
+
+        # Cleanup: restore test key for downstream tests
+        settings.ENCRYPTION_KEY = _TEST_FERNET_KEY
+        settings.ENCRYPTION_KEYS = ""
+        reset_fernet_cache()
+
+    def test_encryption_keys_csv_skips_blank_entries(self):
+        """Whitespace and empty CSV entries must not raise."""
+        from cryptography.fernet import Fernet
+
+        extra_key = Fernet.generate_key().decode()
+        settings.ENCRYPTION_KEYS = f" , {extra_key} , "
+        reset_fernet_cache()
+        try:
+            ct = encrypt("blank-csv-test")
+            assert decrypt(ct) == "blank-csv-test"
+        finally:
+            settings.ENCRYPTION_KEYS = ""
+            reset_fernet_cache()
 
 
 # ── JWT ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Wires `get_multi_fernet()` (previously orphaned in `security.py`) into the encrypt/decrypt path. All encryption now flows through `MultiFernet`, even when only one key is configured.
- Adds optional `ENCRYPTION_KEYS` env var (CSV of past keys). Primary `ENCRYPTION_KEY` is always used to encrypt; legacy keys are tried only for decryption.
- Documents the rotation procedure in `.env.example`.
- Adds `reset_fernet_cache()` helper plus 2 new tests (rotation roundtrip via settings mutation, blank-CSV tolerance) and an empty-list guard.

## Why
Run 3 lessons: `get_multi_fernet` was scaffolded but never wired. Operators currently have no rotation path without code changes.

## Test plan
- [x] `uv run pytest tests/test_security.py -q` — 17/17 pass
- [x] Full backend suite — 123/123 pass
- [x] `ruff check` — clean