### PR TITLE
feat(frontend): POST waitlist signups to backend with localStorage fallback

### DIFF
--- a/frontend/src/__tests__/waitlistform.test.tsx
+++ b/frontend/src/__tests__/waitlistform.test.tsx
@@ -9,6 +9,7 @@ describe("WaitlistForm", () => {
     localStorage.clear();
     // @ts-expect-error — plausible is attached at runtime in production
     window.plausible = vi.fn();
+    vi.restoreAllMocks();
   });
 
   it("renders email input and submit button", () => {
@@ -19,7 +20,8 @@ describe("WaitlistForm", () => {
     ).toBeInTheDocument();
   });
 
-  it("rejects an invalid email and shows alert message", async () => {
+  it("rejects an invalid email and shows alert message without POSTing", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     const user = userEvent.setup();
     render(<WaitlistForm />);
     const input = screen.getByPlaceholderText("you@example.com");
@@ -28,27 +30,75 @@ describe("WaitlistForm", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent(/valid email/i);
     expect(localStorage.getItem("coinhq_waitlist_emails")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("persists a valid email to localStorage and shows status message", async () => {
+  it("successful POST (201) → success state, analytics fired, localStorage mirrored", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "created" }), { status: 201 }),
+    );
     const user = userEvent.setup();
     render(<WaitlistForm />);
-    const input = screen.getByPlaceholderText("you@example.com");
-    await user.type(input, "user@example.com");
+    await user.type(screen.getByPlaceholderText("you@example.com"), "user@example.com");
     await user.click(screen.getByRole("button", { name: /notify me/i }));
 
-    const stored = JSON.parse(
-      localStorage.getItem("coinhq_waitlist_emails") || "[]",
-    );
-    expect(stored).toEqual(["user@example.com"]);
     expect(screen.getByRole("status")).toHaveTextContent(/on the list/i);
+    // localStorage mirrored after backend success
+    const stored = JSON.parse(localStorage.getItem("coinhq_waitlist_emails") || "[]");
+    expect(stored).toContain("user@example.com");
+    // @ts-expect-error — plausible mock
+    expect(window.plausible).toHaveBeenCalled();
   });
 
-  it("treats a re-submission as duplicate and does not double-store", async () => {
+  it("duplicate POST (200) → success state with already-joined message", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "already exists" }), { status: 200 }),
+    );
+    const user = userEvent.setup();
+    render(<WaitlistForm />);
+    await user.type(screen.getByPlaceholderText("you@example.com"), "dup@example.com");
+    await user.click(screen.getByRole("button", { name: /notify me/i }));
+
+    expect(screen.getByRole("status")).toHaveTextContent(/already on the list/i);
+  });
+
+  it("POST network error → falls back to localStorage, still shows success UX", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"));
+    const user = userEvent.setup();
+    render(<WaitlistForm />);
+    await user.type(screen.getByPlaceholderText("you@example.com"), "fallback@example.com");
+    await user.click(screen.getByRole("button", { name: /notify me/i }));
+
+    // Success UX must still render
+    expect(screen.getByRole("status")).toHaveTextContent(/on the list/i);
+    // Email saved to localStorage as fallback
+    const stored = JSON.parse(localStorage.getItem("coinhq_waitlist_emails") || "[]");
+    expect(stored).toContain("fallback@example.com");
+    // Analytics still fires
+    // @ts-expect-error — plausible mock
+    expect(window.plausible).toHaveBeenCalled();
+  });
+
+  it("POST 500 → falls back to localStorage, still shows success UX", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Server error", { status: 500 }),
+    );
+    const user = userEvent.setup();
+    render(<WaitlistForm />);
+    await user.type(screen.getByPlaceholderText("you@example.com"), "err@example.com");
+    await user.click(screen.getByRole("button", { name: /notify me/i }));
+
+    expect(screen.getByRole("status")).toHaveTextContent(/on the list/i);
+    const stored = JSON.parse(localStorage.getItem("coinhq_waitlist_emails") || "[]");
+    expect(stored).toContain("err@example.com");
+  });
+
+  it("treats a localStorage-duplicate re-submission as duplicate and does not double-store", async () => {
     localStorage.setItem(
       "coinhq_waitlist_emails",
       JSON.stringify(["dup@example.com"]),
     );
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("offline"));
     const user = userEvent.setup();
     render(<WaitlistForm />);
     const input = screen.getByPlaceholderText("you@example.com");
@@ -65,6 +115,7 @@ describe("WaitlistForm", () => {
   });
 
   it("normalizes email to lowercase before storing", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("offline"));
     const user = userEvent.setup();
     render(<WaitlistForm />);
     const input = screen.getByPlaceholderText("you@example.com");

--- a/frontend/src/components/WaitlistForm.tsx
+++ b/frontend/src/components/WaitlistForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { events } from '@/lib/analytics'
 
 const STORAGE_KEY = 'coinhq_waitlist_emails'
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
 // Conservative RFC-5322-ish check; intentionally simple — backend will do strict
 // validation when the real signup endpoint lands.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -66,7 +67,7 @@ export default function WaitlistForm({
     }
   }, [])
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault()
     const trimmed = email.trim().toLowerCase()
     if (!EMAIL_RE.test(trimmed)) {
@@ -77,11 +78,39 @@ export default function WaitlistForm({
     }
     setState('submitting')
 
-    const queue = loadQueue()
-    const isDuplicate = queue.includes(trimmed)
-    if (!isDuplicate) {
-      queue.push(trimmed)
-      saveQueue(queue)
+    let isDuplicate = false
+    let backendOk = false
+
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/waitlist`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmed, plan: planName }),
+      })
+      // 201 = new signup, 200 = already on the list — both are success
+      if (res.status === 200 || res.status === 201) {
+        backendOk = true
+        isDuplicate = res.status === 200
+      } else {
+        throw new Error(`Unexpected status ${res.status}`)
+      }
+    } catch {
+      // Network error or non-2xx: fall back to localStorage so CTA never breaks
+      const queue = loadQueue()
+      isDuplicate = queue.includes(trimmed)
+      if (!isDuplicate) {
+        queue.push(trimmed)
+        saveQueue(queue)
+      }
+    }
+
+    // If backend succeeded, still mirror to localStorage for the "already subscribed" hint on reload
+    if (backendOk) {
+      const queue = loadQueue()
+      if (!queue.includes(trimmed)) {
+        queue.push(trimmed)
+        saveQueue(queue)
+      }
     }
 
     // Fire analytics — this is the durable signal even if storage is blocked.


### PR DESCRIPTION
## Summary
- Wires `WaitlistForm` to `POST /api/v1/waitlist` with `{ email, plan }` using `NEXT_PUBLIC_API_URL` base
- Treats HTTP 201 (new) and 200 (duplicate) both as success; shows appropriate message for each
- On network error or non-2xx response, gracefully falls back to existing localStorage write so the CTA never appears broken
- Plausible `Waitlist Submitted` analytics event fires in all paths (durable signal)
- All existing a11y (role=alert/status, labelled input, aria-invalid) preserved; no `any` types introduced

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `CI=1 npx vitest run` — 31/31 tests pass (5 test files)
- [x] New test: successful POST (201) → success state + localStorage mirrored
- [x] New test: duplicate POST (200) → "already on the list" message
- [x] New test: network error → localStorage fallback + success UX
- [x] New test: HTTP 500 → localStorage fallback + success UX
- [x] Existing: invalid email rejected client-side without fetch call

🤖 Generated with [Claude Code](https://claude.com/claude-code)