### PR TITLE
feat(frontend): transaction history view for owner trades

### DIFF
--- a/frontend/src/__tests__/tradehistory.test.tsx
+++ b/frontend/src/__tests__/tradehistory.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { TradeOrder } from "@/lib/types";
+
+// ── SWR mock ─────────────────────────────────────────────────────────────────
+// We control the hook's return value per-test via this variable.
+let mockHookReturn: {
+  trades: TradeOrder[] | undefined;
+  error: Error | undefined;
+  isLoading: boolean;
+} = { trades: undefined, error: undefined, isLoading: false };
+
+vi.mock("@/hooks/usePortfolio", () => ({
+  useTradeHistory: () => mockHookReturn,
+}));
+
+// Import after mocking
+import TradeHistory from "@/components/TradeHistory";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const makeTrade = (overrides: Partial<TradeOrder> = {}): TradeOrder => ({
+  id: 1,
+  exchange: "binance",
+  symbol: "BTCUSDT",
+  base_asset: "BTC",
+  side: "buy",
+  usd_value: 250.5,
+  amount: 0.005,
+  actor: "owner",
+  status: "filled",
+  exchange_order_id: "EX-001",
+  error: null,
+  created_at: "2026-06-06T10:00:00.000Z",
+  ...overrides,
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("TradeHistory", () => {
+  beforeEach(() => {
+    mockHookReturn = { trades: undefined, error: undefined, isLoading: false };
+  });
+
+  it("renders trade rows from a mocked list", () => {
+    const trades = [
+      makeTrade({ id: 1, base_asset: "BTC", usd_value: 250.5 }),
+      makeTrade({ id: 2, base_asset: "ETH", side: "sell", usd_value: 100 }),
+    ];
+    mockHookReturn = { trades, error: undefined, isLoading: false };
+
+    render(<TradeHistory profileId={1} />);
+
+    expect(screen.getByText("BTC")).toBeInTheDocument();
+    expect(screen.getByText("ETH")).toBeInTheDocument();
+    expect(screen.getByText("$250.50")).toBeInTheDocument();
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+  });
+
+  it("shows empty state when trade list is empty", () => {
+    mockHookReturn = { trades: [], error: undefined, isLoading: false };
+
+    render(<TradeHistory profileId={1} />);
+
+    expect(screen.getByText(/no trades yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows error text and styling for a failed-status row", () => {
+    const trades = [
+      makeTrade({
+        id: 3,
+        status: "failed",
+        error: "Insufficient balance",
+        base_asset: "SOL",
+      }),
+    ];
+    mockHookReturn = { trades, error: undefined, isLoading: false };
+
+    render(<TradeHistory profileId={1} />);
+
+    // The status badge says "failed"
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    // The error message is displayed inline
+    expect(screen.getByText(/insufficient balance/i)).toBeInTheDocument();
+    // The row has the failed highlight class (via the tr element)
+    const row = screen.getByText("SOL").closest("tr");
+    expect(row?.className).toMatch(/red/);
+  });
+
+  it("distinguishes buy vs sell with different visual classes", () => {
+    const trades = [
+      makeTrade({ id: 1, side: "buy" }),
+      makeTrade({ id: 2, side: "sell" }),
+    ];
+    mockHookReturn = { trades, error: undefined, isLoading: false };
+
+    render(<TradeHistory profileId={1} />);
+
+    const buyBadge = screen.getByText("buy");
+    const sellBadge = screen.getByText("sell");
+
+    expect(buyBadge.className).toMatch(/green/);
+    expect(sellBadge.className).toMatch(/red/);
+  });
+
+  it("shows a hint when no profile is selected (aggregate view)", () => {
+    render(<TradeHistory profileId={null} />);
+
+    expect(screen.getByText(/select a profile/i)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while fetching", () => {
+    mockHookReturn = { trades: undefined, error: undefined, isLoading: true };
+
+    render(<TradeHistory profileId={1} />);
+
+    expect(screen.getByRole("status", { name: /loading trade history/i })).toBeInTheDocument();
+  });
+
+  it("shows an error alert when the hook returns an error", () => {
+    mockHookReturn = {
+      trades: undefined,
+      error: new Error("Network timeout"),
+      isLoading: false,
+    };
+
+    render(<TradeHistory profileId={1} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert.textContent).toMatch(/network timeout/i);
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { PortfolioSkeleton } from "@/components/SkeletonCard";
 import { Navigation } from "@/components/Navigation";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
+import TradeHistory from "@/components/TradeHistory";
 
 const AllocationChart = dynamic(() => import("@/components/AllocationChart"), { ssr: false });
 
@@ -101,6 +102,14 @@ export default function DashboardPage() {
             <AllocationChart exchanges={exchanges} />
             <ExchangeList exchanges={exchanges} />
           </div>
+        </div>
+      )}
+
+      {/* Trade History */}
+      {!loading && portfolio && (
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold text-white mb-2">Recent Trades</h2>
+          <TradeHistory profileId={typeof selectedProfileId === "number" ? selectedProfileId : null} />
         </div>
       )}
 

--- a/frontend/src/components/TradeHistory.tsx
+++ b/frontend/src/components/TradeHistory.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import type { TradeOrder } from "@/lib/types";
+import { useTradeHistory } from "@/hooks/usePortfolio";
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(iso));
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SideBadge({ side }: { side: TradeOrder["side"] }) {
+  const isBuy = side === "buy";
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold uppercase ${
+        isBuy ? "bg-green-900/50 text-green-400" : "bg-red-900/50 text-red-400"
+      }`}
+    >
+      {side}
+    </span>
+  );
+}
+
+function StatusBadge({ status, error }: { status: TradeOrder["status"]; error: string | null }) {
+  const styles: Record<string, string> = {
+    filled: "bg-green-900/50 text-green-400",
+    pending: "bg-amber-900/50 text-amber-400",
+    failed: "bg-red-900/50 text-red-400",
+  };
+  const cls = styles[status] ?? "bg-gray-800 text-gray-400";
+
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold capitalize ${cls}`}
+      title={status === "failed" && error ? error : undefined}
+    >
+      {status}
+      {status === "failed" && error && (
+        <span className="ml-1 text-red-300 text-xs" aria-label={`Error: ${error}`}>
+          {" "}({error})
+        </span>
+      )}
+    </span>
+  );
+}
+
+function ActorBadge({ actor }: { actor: string }) {
+  const isOwner = actor === "owner";
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium capitalize ${
+        isOwner ? "bg-blue-900/50 text-blue-300" : "bg-purple-900/50 text-purple-300"
+      }`}
+    >
+      {actor}
+    </span>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface TradeHistoryProps {
+  profileId: number | null;
+}
+
+export default function TradeHistory({ profileId }: TradeHistoryProps) {
+  const { trades, error, isLoading } = useTradeHistory(profileId);
+
+  if (profileId == null) {
+    return (
+      <div
+        role="status"
+        className="mt-4 p-4 bg-gray-800/50 rounded-lg text-gray-400 text-sm text-center"
+      >
+        Select a profile to view trade history.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="Loading trade history"
+        className="mt-4 space-y-2"
+      >
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-12 bg-gray-800 rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="mt-4 p-4 bg-red-900/30 border border-red-700 rounded-lg text-red-300 text-sm"
+      >
+        Failed to load trade history: {error.message ?? String(error)}
+      </div>
+    );
+  }
+
+  if (!trades || trades.length === 0) {
+    return (
+      <div
+        role="status"
+        className="mt-4 p-8 text-center text-gray-500 text-sm bg-gray-800/30 rounded-lg"
+      >
+        No trades yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 overflow-x-auto rounded-lg border border-gray-700">
+      <table className="min-w-full divide-y divide-gray-700 text-sm">
+        <thead className="bg-gray-800/60">
+          <tr>
+            {["Date", "Side", "Asset", "Exchange", "Amount", "USD Value", "Actor", "Status"].map(
+              (h) => (
+                <th
+                  key={h}
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-700/50">
+          {trades.map((t) => (
+            <tr
+              key={t.id}
+              className={`transition-colors hover:bg-gray-800/40 ${
+                t.status === "failed" ? "bg-red-950/20" : ""
+              }`}
+            >
+              <td className="px-4 py-3 text-gray-300 whitespace-nowrap">{formatDate(t.created_at)}</td>
+              <td className="px-4 py-3">
+                <SideBadge side={t.side} />
+              </td>
+              <td className="px-4 py-3 font-medium text-white">{t.base_asset}</td>
+              <td className="px-4 py-3 text-gray-300 capitalize">{t.exchange}</td>
+              <td className="px-4 py-3 text-gray-300">
+                {t.amount != null ? t.amount.toFixed(6) : "—"}
+              </td>
+              <td className="px-4 py-3 text-gray-100 font-medium">{formatUsd(t.usd_value)}</td>
+              <td className="px-4 py-3">
+                <ActorBadge actor={t.actor} />
+              </td>
+              <td className="px-4 py-3">
+                <StatusBadge status={t.status} error={t.error} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr'
+import type { TradeOrder } from '@/lib/types'
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
 
@@ -18,4 +19,17 @@ export function usePortfolio(profileId: number) {
 export function useProfiles() {
   const { data, error, isLoading } = useSWR(`${BASE_URL}/api/v1/profiles/`, fetcher)
   return { profiles: data, error, isLoading }
+}
+
+export function useTradeHistory(profileId: number | null) {
+  const { data, error, isLoading } = useSWR<TradeOrder[]>(
+    profileId != null ? `${BASE_URL}/api/v1/profiles/${profileId}/trade` : null,
+    fetcher
+  )
+  const sorted = data
+    ? [...data].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      )
+    : data
+  return { trades: sorted, error, isLoading }
 }


### PR DESCRIPTION
## Summary
- Adds `useTradeHistory(profileId)` SWR hook in `usePortfolio.ts` calling `GET /api/v1/profiles/{profile_id}/trade`, sorted client-side newest-first
- Adds `TradeHistory` component: full responsive table with date, side badge (green buy / red sell), base_asset, exchange, amount, USD value, actor badge, and status badge (filled=green, pending=amber, failed=red with inline error text); handles loading skeletons, empty state, error alert, and aggregate-view hint — all with correct ARIA roles
- Surfaces a "Recent Trades" section at the bottom of the dashboard page; respects selected profile, shows hint when aggregate is selected

## Test plan
- [ ] `npx tsc --noEmit` — passes (0 errors)
- [ ] `CI=1 npx vitest run` — 38 tests pass (7 new in `tradehistory.test.tsx`)
  - rows rendered from mocked list
  - empty state shown
  - failed-status row shows error text and red row class
  - buy vs sell badges have different color classes
  - null profileId shows "Select a profile" hint
  - loading state shows skeleton with role=status
  - hook error shows role=alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)