### PR TITLE
feat(backend): CoinGecko price fallback for assets without Binance USDT pair

### DIFF
--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -1,6 +1,6 @@
 """
 Price service: fetch USDT prices from exchange public APIs.
-Priority: Binance public API (no auth, 3500+ pairs) → fallback $0
+Priority: Binance public API (no auth, 3500+ pairs) → CoinGecko fallback → $0
 All prices are in USDT ≈ USD.
 """
 
@@ -10,11 +10,21 @@ import logging
 import httpx
 import redis.asyncio as aioredis
 
+from app.core.config import settings
+
 _logger = logging.getLogger(__name__)
 
 # Redis key for full Binance price map (all pairs)
 _BINANCE_PRICE_CACHE_KEY = "binance:all_prices"
 _BINANCE_PRICE_TTL = 30  # seconds
+
+# Redis key for CoinGecko symbol→id map (large and stable, cache 24h)
+_CG_COIN_LIST_CACHE_KEY = "coingecko:coin_list"
+_CG_COIN_LIST_TTL = 86_400  # 24 hours
+
+# Redis key prefix for CoinGecko per-coin USD prices
+_CG_PRICE_CACHE_PREFIX = "coingecko:price:"
+_CG_PRICE_TTL = 60  # seconds — consistent with Binance TTL range
 
 
 async def _fetch_binance_all_prices(
@@ -54,6 +64,148 @@ async def _fetch_binance_all_prices(
     return prices
 
 
+async def _get_coingecko_symbol_map(
+    http_client: httpx.AsyncClient,
+    redis_client: aioredis.Redis | None,
+) -> dict[str, str]:
+    """
+    Return a symbol→coingecko_id map built from /coins/list.
+
+    Disambiguation heuristic (best-effort fallback — not authoritative):
+      1. If an id exactly equals the lowercased symbol, prefer it.
+      2. Otherwise take the first match in the list (CoinGecko returns by
+         market-cap rank descending for well-known coins, so the first hit
+         is usually the most prominent one).
+    This is intentionally simple; the goal is to price dust/low-cap holdings
+    that Binance doesn't list, not to be a canonical coin registry.
+    """
+    # Try Redis cache
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(_CG_COIN_LIST_CACHE_KEY)
+            if cached:
+                return json.loads(cached)
+        except Exception as e:
+            _logger.warning("Redis CoinGecko coin-list cache read failed: %s", e)
+
+    try:
+        resp = await http_client.get(
+            f"{settings.COINGECKO_BASE_URL}/coins/list",
+            timeout=15,
+        )
+        resp.raise_for_status()
+        coins: list[dict[str, str]] = resp.json()
+    except Exception as e:
+        _logger.warning("CoinGecko /coins/list fetch failed: %s", e)
+        return {}
+
+    symbol_map: dict[str, str] = {}
+    for coin in coins:
+        sym = coin.get("symbol", "").upper()
+        cg_id = coin.get("id", "")
+        if not sym or not cg_id:
+            continue
+        if sym not in symbol_map:
+            # First occurrence wins unless a better match is found below
+            symbol_map[sym] = cg_id
+        elif cg_id == sym.lower():
+            # Exact lowercase-symbol == id is the canonical/well-known coin
+            symbol_map[sym] = cg_id
+
+    if symbol_map and redis_client is not None:
+        try:
+            await redis_client.setex(
+                _CG_COIN_LIST_CACHE_KEY, _CG_COIN_LIST_TTL, json.dumps(symbol_map)
+            )
+        except Exception as e:
+            _logger.warning("Redis CoinGecko coin-list cache write failed: %s", e)
+
+    return symbol_map
+
+
+async def _fetch_coingecko_prices(
+    symbols: list[str],
+    http_client: httpx.AsyncClient,
+    redis_client: aioredis.Redis | None,
+) -> dict[str, float]:
+    """
+    Fetch USD prices from CoinGecko for the given asset symbols.
+    Returns a symbol→price dict for whatever was found.
+    Errors are logged and swallowed — callers receive a partial/empty result.
+    """
+    if not symbols:
+        return {}
+
+    symbol_map = await _get_coingecko_symbol_map(http_client, redis_client)
+    if not symbol_map:
+        return {}
+
+    # Map requested symbols to CoinGecko ids
+    sym_to_id: dict[str, str] = {}
+    for sym in symbols:
+        cg_id = symbol_map.get(sym.upper())
+        if cg_id:
+            sym_to_id[sym] = cg_id
+
+    if not sym_to_id:
+        return {}
+
+    # Check per-coin Redis cache first
+    prices: dict[str, float] = {}
+    uncached_syms: list[str] = []
+    if redis_client is not None:
+        for sym in sym_to_id:
+            try:
+                cached = await redis_client.get(f"{_CG_PRICE_CACHE_PREFIX}{sym}")
+                if cached is not None:
+                    prices[sym] = float(cached)
+                else:
+                    uncached_syms.append(sym)
+            except Exception as e:
+                _logger.warning("Redis CoinGecko price cache read failed: %s", e)
+                uncached_syms.append(sym)
+    else:
+        uncached_syms = list(sym_to_id)
+
+    if not uncached_syms:
+        return prices
+
+    ids_param = ",".join(sym_to_id[s] for s in uncached_syms)
+    try:
+        resp = await http_client.get(
+            f"{settings.COINGECKO_BASE_URL}/simple/price",
+            params={"ids": ids_param, "vs_currencies": "usd"},
+            timeout=10,
+        )
+        if resp.status_code == 429:
+            _logger.warning("CoinGecko rate-limited (429) — skipping fallback prices")
+            return prices
+        resp.raise_for_status()
+        data: dict[str, dict[str, float]] = resp.json()
+    except Exception as e:
+        _logger.warning("CoinGecko /simple/price fetch failed: %s", e)
+        return prices
+
+    for sym in uncached_syms:
+        cg_id = sym_to_id[sym]
+        usd = data.get(cg_id, {}).get("usd")
+        if usd is not None:
+            prices[sym] = float(usd)
+            if redis_client is not None:
+                try:
+                    await redis_client.setex(
+                        f"{_CG_PRICE_CACHE_PREFIX}{sym}",
+                        _CG_PRICE_TTL,
+                        str(usd),
+                    )
+                except Exception as e:
+                    _logger.warning(
+                        "Redis CoinGecko price cache write failed for %s: %s", sym, e
+                    )
+
+    return prices
+
+
 async def get_usd_prices(
     assets: list[str],
     http_client: httpx.AsyncClient | None = None,
@@ -61,32 +213,56 @@ async def get_usd_prices(
 ) -> dict[str, float]:
     """
     Return USD prices for the given asset symbols.
-    Uses Binance public ticker (no API key needed).
-    Redis caches the full price map for 30s to avoid repeated fetches.
+
+    Primary:  Binance public ticker (no API key needed), cached in Redis 30s.
+    Fallback: CoinGecko /simple/price for assets without a Binance USDT pair,
+              cached per-coin in Redis 60s.
+    Stablecoins are hardcoded to $1 and never sent to CoinGecko.
+    Any CoinGecko error/timeout is logged and swallowed — never raised.
     """
     if not assets:
         return {}
 
-    all_prices: dict[str, float] | None = None
+    close_client = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=10)
 
-    # Try Redis cache first
-    if redis_client is not None:
-        try:
-            cached = await redis_client.get(_BINANCE_PRICE_CACHE_KEY)
-            if cached:
-                all_prices = json.loads(cached)
-        except Exception as e:
-            _logger.warning("Redis price cache read failed: %s", e)
+    try:
+        all_prices: dict[str, float] | None = None
 
-    # Fetch from Binance if not cached
-    if all_prices is None:
-        all_prices = await _fetch_binance_all_prices(http_client)
-        if all_prices and redis_client is not None:
+        # Try Redis cache first
+        if redis_client is not None:
             try:
-                await redis_client.setex(
-                    _BINANCE_PRICE_CACHE_KEY, _BINANCE_PRICE_TTL, json.dumps(all_prices)
-                )
+                cached = await redis_client.get(_BINANCE_PRICE_CACHE_KEY)
+                if cached:
+                    all_prices = json.loads(cached)
             except Exception as e:
-                _logger.warning("Redis price cache write failed: %s", e)
+                _logger.warning("Redis price cache read failed: %s", e)
 
-    return {asset: all_prices[asset] for asset in assets if asset in all_prices}
+        # Fetch from Binance if not cached
+        if all_prices is None:
+            all_prices = await _fetch_binance_all_prices(client)
+            if all_prices and redis_client is not None:
+                try:
+                    await redis_client.setex(
+                        _BINANCE_PRICE_CACHE_KEY,
+                        _BINANCE_PRICE_TTL,
+                        json.dumps(all_prices),
+                    )
+                except Exception as e:
+                    _logger.warning("Redis price cache write failed: %s", e)
+
+        result: dict[str, float] = {
+            asset: all_prices[asset] for asset in assets if asset in all_prices
+        }
+
+        # CoinGecko fallback for assets that Binance didn't price
+        unpriced = [a for a in assets if a not in result]
+        if unpriced:
+            cg_prices = await _fetch_coingecko_prices(unpriced, client, redis_client)
+            result.update(cg_prices)
+
+        return result
+
+    finally:
+        if close_client:
+            await client.aclose()

--- a/backend/tests/test_price_service.py
+++ b/backend/tests/test_price_service.py
@@ -8,6 +8,7 @@ os.environ.setdefault("JWT_SECRET", "test-jwt-secret-for-unit-tests-only")
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from app.services.price_service import _fetch_binance_all_prices, get_usd_prices
@@ -131,3 +132,265 @@ class TestGetUsdPrices:
         assert "BTC" in result
         assert "DOGE" not in result
         assert "ETH" not in result
+
+
+# ---------------------------------------------------------------------------
+# CoinGecko fallback tests
+# ---------------------------------------------------------------------------
+
+
+def _make_binance_resp(pairs: list[tuple[str, str]]) -> MagicMock:
+    """Build a mock Binance ticker response for the given (symbol, price) pairs."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [
+        {"symbol": sym, "price": price} for sym, price in pairs
+    ]
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+def _make_cg_coins_resp(coins: list[dict]) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = coins
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.status_code = 200
+    return mock_resp
+
+
+def _make_cg_price_resp(data: dict) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = data
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.status_code = 200
+    return mock_resp
+
+
+class TestCoinGeckoFallback:
+    """
+    Tests for the CoinGecko fallback path in get_usd_prices.
+    All tests mock HTTP responses — no real network calls.
+    """
+
+    @pytest.mark.asyncio
+    async def test_asset_on_binance_not_priced_via_coingecko(self):
+        """Asset present on Binance → priced via Binance, CoinGecko NOT called."""
+        binance_resp = _make_binance_resp([("BTCUSDT", "65000.0")])
+
+        call_count = 0
+
+        async def mock_get(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "binance.com" in url:
+                return binance_resp
+            raise AssertionError(f"Unexpected URL called: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        result = await get_usd_prices(
+            ["BTC"], http_client=mock_client, redis_client=mock_redis
+        )
+
+        assert result["BTC"] == 65000.0
+        # Only Binance was called (1 call)
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_asset_missing_on_binance_priced_via_coingecko(self):
+        """Asset missing on Binance but present on CoinGecko → priced via CoinGecko."""
+        binance_resp = _make_binance_resp([])  # no USDT pairs at all
+
+        coin_list_resp = _make_cg_coins_resp(
+            [{"id": "mytoken", "symbol": "MTK", "name": "MyToken"}]
+        )
+        cg_price_resp = _make_cg_price_resp({"mytoken": {"usd": 0.042}})
+
+        call_responses = {
+            "binance.com": binance_resp,
+            "coins/list": coin_list_resp,
+            "simple/price": cg_price_resp,
+        }
+
+        async def mock_get(url, **kwargs):
+            for key, resp in call_responses.items():
+                if key in url:
+                    return resp
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        result = await get_usd_prices(
+            ["MTK"], http_client=mock_client, redis_client=mock_redis
+        )
+
+        assert result["MTK"] == pytest.approx(0.042)
+
+    @pytest.mark.asyncio
+    async def test_coingecko_error_leaves_asset_unpriced_no_exception(self):
+        """CoinGecko error/timeout → asset left unpriced, no exception raised."""
+        binance_resp = _make_binance_resp([])  # no pairs
+
+        call_count = {"coins_list": 0}
+
+        async def mock_get(url, **kwargs):
+            if "binance.com" in url:
+                return binance_resp
+            if "coins/list" in url:
+                call_count["coins_list"] += 1
+                raise httpx.TimeoutException("timeout")
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        # Must not raise
+        result = await get_usd_prices(
+            ["UNKNOWNCOIN"], http_client=mock_client, redis_client=mock_redis
+        )
+
+        assert "UNKNOWNCOIN" not in result
+        assert call_count["coins_list"] == 1
+
+    @pytest.mark.asyncio
+    async def test_coingecko_rate_limit_leaves_asset_unpriced_no_exception(self):
+        """CoinGecko 429 → asset left unpriced, no exception raised."""
+        binance_resp = _make_binance_resp([])
+
+        coin_list_resp = _make_cg_coins_resp(
+            [{"id": "mytoken", "symbol": "MTK", "name": "MyToken"}]
+        )
+
+        rate_limit_resp = MagicMock()
+        rate_limit_resp.status_code = 429
+        rate_limit_resp.raise_for_status = MagicMock()
+
+        async def mock_get(url, **kwargs):
+            if "binance.com" in url:
+                return binance_resp
+            if "coins/list" in url:
+                return coin_list_resp
+            if "simple/price" in url:
+                return rate_limit_resp
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        result = await get_usd_prices(
+            ["MTK"], http_client=mock_client, redis_client=mock_redis
+        )
+
+        assert "MTK" not in result
+
+    @pytest.mark.asyncio
+    async def test_symbol_to_id_map_cached_in_redis(self):
+        """CoinGecko symbol→id map is written to Redis and read from cache on second call."""
+        binance_resp = _make_binance_resp([])
+
+        coin_list_resp = _make_cg_coins_resp(
+            [{"id": "mytoken", "symbol": "MTK", "name": "MyToken"}]
+        )
+        cg_price_resp = _make_cg_price_resp({"mytoken": {"usd": 1.5}})
+
+        # Simulate: first call has no Binance cache and no CoinGecko coin-list cache
+        get_call_count = {"coins_list": 0}
+
+        async def mock_get(url, **kwargs):
+            if "binance.com" in url:
+                return binance_resp
+            if "coins/list" in url:
+                get_call_count["coins_list"] += 1
+                return coin_list_resp
+            if "simple/price" in url:
+                return cg_price_resp
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        setex_calls: list[str] = []
+
+        async def mock_setex(key, ttl, value):
+            setex_calls.append(key)
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = mock_setex
+
+        await get_usd_prices(["MTK"], http_client=mock_client, redis_client=mock_redis)
+
+        # The coin-list cache key must have been written
+        assert any("coin_list" in k for k in setex_calls), (
+            f"coin_list key not in setex calls: {setex_calls}"
+        )
+        # /coins/list was fetched exactly once
+        assert get_call_count["coins_list"] == 1
+
+    @pytest.mark.asyncio
+    async def test_symbol_id_disambiguation_exact_match_preferred(self):
+        """
+        When multiple coins share a ticker, the one whose id == lowercased symbol
+        is preferred over the first match.
+        """
+        binance_resp = _make_binance_resp([])
+
+        # 'xrp' appears first as 'xrp-legacy' then the canonical 'xrp'
+        coin_list_resp = _make_cg_coins_resp(
+            [
+                {"id": "xrp-legacy", "symbol": "XRP", "name": "XRP Legacy"},
+                {"id": "xrp", "symbol": "XRP", "name": "XRP"},
+            ]
+        )
+        # Only the canonical id 'xrp' will be queried
+        cg_price_resp = _make_cg_price_resp({"xrp": {"usd": 0.5}})
+
+        async def mock_get(url, **kwargs):
+            if "binance.com" in url:
+                return binance_resp
+            if "coins/list" in url:
+                return coin_list_resp
+            if "simple/price" in url:
+                # Verify the canonical id was sent
+                params = kwargs.get("params", {})
+                assert "xrp" in params.get("ids", ""), (
+                    f"Expected canonical id 'xrp' in ids, got: {params}"
+                )
+                return cg_price_resp
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        result = await get_usd_prices(
+            ["XRP"], http_client=mock_client, redis_client=mock_redis
+        )
+
+        assert result["XRP"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- After Binance pricing, assets with no USDT pair are resolved via CoinGecko `/simple/price` as a best-effort fallback (never raises)
- Symbol→CoinGecko id map built from `/coins/list`, cached in Redis for 24h (large/stable); per-coin prices cached 60s matching Binance TTL range
- Disambiguation heuristic: prefer id == lowercased symbol (canonical well-known coin), else first match in CoinGecko list
- CoinGecko errors (timeout, 429, parse failure) are logged and swallowed — Binance primary path is completely untouched; stablecoins stay hardcoded

## Test plan
- [x] Asset on Binance → priced via Binance, CoinGecko NOT called
- [x] Asset missing on Binance but on CoinGecko → priced via CoinGecko fallback
- [x] CoinGecko timeout → asset left unpriced, no exception raised
- [x] CoinGecko 429 rate-limit → asset left unpriced, no exception raised
- [x] Symbol→id map written to Redis cache (coin_list key)
- [x] Canonical id disambiguation (id == lowercased symbol preferred)
- [x] `uv run pytest tests/test_price_service.py -q` → 14 passed
- [x] `uv run pytest -q` → 175 passed, 0 failures
- [x] `uv run ruff check` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)