### PR TITLE
feat(backend): historical portfolio snapshots + GET /profiles/{id}/history

### DIFF
--- a/backend/alembic/versions/010_add_portfolio_snapshots.py
+++ b/backend/alembic/versions/010_add_portfolio_snapshots.py
@@ -1,0 +1,34 @@
+"""add portfolio_snapshots table
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-06-06
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolio_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("profile_id", sa.Integer(), sa.ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("total_usd", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_portfolio_snapshots_profile_id", "portfolio_snapshots", ["profile_id"])
+    op.create_index("ix_portfolio_snapshots_profile_id_created_at", "portfolio_snapshots", ["profile_id", "created_at"])
+    op.create_index("ix_portfolio_snapshots_created_at", "portfolio_snapshots", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_portfolio_snapshots_created_at", table_name="portfolio_snapshots")
+    op.drop_index("ix_portfolio_snapshots_profile_id_created_at", table_name="portfolio_snapshots")
+    op.drop_index("ix_portfolio_snapshots_profile_id", table_name="portfolio_snapshots")
+    op.drop_table("portfolio_snapshots")

--- a/backend/app/api/v1/history.py
+++ b/backend/app/api/v1/history.py
@@ -1,0 +1,54 @@
+"""Portfolio history endpoint — GET /profiles/{profile_id}/history."""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.portfolio_snapshot import PortfolioSnapshot
+from app.models.profile import Profile
+from app.models.user import User
+from app.schemas.portfolio import PortfolioHistoryPoint
+
+router = APIRouter(prefix="/profiles/{profile_id}/history", tags=["history"])
+
+_MAX_DAYS = 365
+
+
+async def _get_owned_profile(
+    profile_id: int,
+    db: AsyncSession,
+    current_user: User,
+) -> Profile:
+    profile = await db.get(Profile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    if profile.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    return profile
+
+
+@router.get("/", response_model=list[PortfolioHistoryPoint])
+async def portfolio_history(
+    profile_id: int,
+    days: int = Query(default=30, ge=1, le=_MAX_DAYS),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[PortfolioHistoryPoint]:
+    """Return portfolio value snapshots for the last N days, oldest→newest."""
+    await _get_owned_profile(profile_id, db, current_user)
+
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    result = await db.execute(
+        select(PortfolioSnapshot)
+        .where(
+            PortfolioSnapshot.profile_id == profile_id,
+            PortfolioSnapshot.created_at >= cutoff,
+        )
+        .order_by(PortfolioSnapshot.created_at.asc())
+    )
+    snapshots = result.scalars().all()
+    return [PortfolioHistoryPoint.model_validate(s) for s in snapshots]

--- a/backend/app/api/v1/portfolio.py
+++ b/backend/app/api/v1/portfolio.py
@@ -43,6 +43,7 @@ async def portfolio_for_profile(
         keys,
         redis=request.app.state.redis,
         http_client=request.app.state.http_client,
+        db=db,
     )
 
 

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,12 +1,13 @@
 from fastapi import APIRouter
 
-from app.api.v1 import admin, auth, keys, portfolio, profiles, share, trade, waitlist
+from app.api.v1 import admin, auth, history, keys, portfolio, profiles, share, trade, waitlist
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(auth.router)
 router.include_router(profiles.router)
 router.include_router(keys.router)
 router.include_router(portfolio.router)
+router.include_router(history.router)
 router.include_router(share.router)
 router.include_router(trade.router)
 router.include_router(admin.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,9 +1,10 @@
 from app.models.exchange_key import ExchangeKey
 from app.models.followed_portfolio import FollowedPortfolio
+from app.models.portfolio_snapshot import PortfolioSnapshot
 from app.models.profile import Profile
 from app.models.share_link import ShareLink
 from app.models.trade_order import TradeOrder
 from app.models.user import User
 from app.models.waitlist import Waitlist
 
-__all__ = ["User", "Profile", "ExchangeKey", "ShareLink", "FollowedPortfolio", "TradeOrder", "Waitlist"]
+__all__ = ["User", "Profile", "ExchangeKey", "ShareLink", "FollowedPortfolio", "TradeOrder", "Waitlist", "PortfolioSnapshot"]

--- a/backend/app/models/portfolio_snapshot.py
+++ b/backend/app/models/portfolio_snapshot.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, func
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class PortfolioSnapshot(Base):
+    """Point-in-time record of a profile's total portfolio value in USD.
+
+    Written at most once per hour per profile when the portfolio is fetched.
+    Used to power the portfolio history chart on the dashboard.
+    """
+
+    __tablename__ = "portfolio_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    profile_id = Column(Integer, ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False, index=True)
+    total_usd = Column(Float, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
+
+    profile = relationship("Profile")

--- a/backend/app/schemas/portfolio.py
+++ b/backend/app/schemas/portfolio.py
@@ -1,5 +1,6 @@
+from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Balance(BaseModel):
@@ -35,3 +36,10 @@ class AggregatePortfolioResponse(BaseModel):
     profiles: list[ProfilePortfolio]
     grand_total_usd: float
     asset_totals: dict[str, float]  # asset -> total USD across all profiles
+
+
+class PortfolioHistoryPoint(BaseModel):
+    created_at: datetime
+    total_usd: float
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/portfolio_service.py
+++ b/backend/app/services/portfolio_service.py
@@ -6,15 +6,19 @@ price them in USD via exchange public APIs, cache results in Redis.
 import asyncio
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import redis.asyncio as aioredis
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging import logger
 from app.core.security import decrypt
 from app.exchanges.factory import get_adapter
 from app.models.exchange_key import ExchangeKey
+from app.models.portfolio_snapshot import PortfolioSnapshot
 from app.schemas.portfolio import (
     AggregatePortfolioResponse,
     Balance,
@@ -23,6 +27,8 @@ from app.schemas.portfolio import (
     ProfilePortfolio,
 )
 from app.services.price_service import get_usd_prices
+
+_SNAPSHOT_THROTTLE_HOURS = 1
 
 _stdlib_logger = logging.getLogger(__name__)
 
@@ -69,12 +75,38 @@ def _build_exchange_balance(
     )
 
 
+async def _maybe_save_snapshot(
+    profile_id: int,
+    total_usd: float,
+    db: AsyncSession,
+) -> None:
+    """Persist a portfolio snapshot at most once per hour. Best-effort only."""
+    try:
+        cutoff = datetime.now(UTC) - timedelta(hours=_SNAPSHOT_THROTTLE_HOURS)
+        result = await db.execute(
+            select(PortfolioSnapshot)
+            .where(
+                PortfolioSnapshot.profile_id == profile_id,
+                PortfolioSnapshot.created_at >= cutoff,
+            )
+            .limit(1)
+        )
+        recent = result.scalars().first()
+        if recent is None:
+            snapshot = PortfolioSnapshot(profile_id=profile_id, total_usd=total_usd)
+            db.add(snapshot)
+            await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("portfolio_snapshot_write_failed", profile_id=profile_id, error=str(exc))
+
+
 async def get_portfolio(
     profile_id: int,
     profile_name: str,
     keys: list[ExchangeKey],
     redis: aioredis.Redis | None = None,
     http_client: httpx.AsyncClient | None = None,
+    db: AsyncSession | None = None,
 ) -> PortfolioResponse:
     """Get portfolio for a single profile with Redis caching."""
     cache_key = f"portfolio:profile:{profile_id}"
@@ -113,6 +145,9 @@ async def get_portfolio(
     ]
 
     total_usd = sum(eb.total_usd for eb in exchange_balances)
+
+    if db is not None:
+        await _maybe_save_snapshot(profile_id, total_usd, db)
 
     response = PortfolioResponse(
         profile_id=profile_id,

--- a/backend/tests/test_portfolio_history.py
+++ b/backend/tests/test_portfolio_history.py
@@ -1,0 +1,263 @@
+"""
+Tests for portfolio history — T-019:
+  (a) history endpoint returns stored snapshots filtered by days, scoped to owner
+  (b) throttle — two computes within an hour produce only one snapshot
+  (c) snapshot write failure does not break portfolio response
+  (d) days param cap/validation
+"""
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("ENCRYPTION_KEY", "dGVzdC1lbmNyeXB0aW9uLWtleS0zMi1ieXRlc3h4")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-for-unit-tests-only")
+
+from fastapi import HTTPException
+
+from app.api.v1.history import portfolio_history
+from app.services.portfolio_service import _maybe_save_snapshot, get_portfolio
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(user_id: int = 1):
+    u = MagicMock()
+    u.id = user_id
+    return u
+
+
+def _make_profile(profile_id: int = 1, owner_id: int = 1):
+    p = MagicMock()
+    p.id = profile_id
+    p.user_id = owner_id
+    p.name = "Test"
+    return p
+
+
+def _make_snapshot(profile_id: int = 1, total_usd: float = 100.0, delta_hours: int = 0):
+    s = MagicMock()
+    s.id = 1
+    s.profile_id = profile_id
+    s.total_usd = total_usd
+    s.created_at = datetime.now(UTC) - timedelta(hours=delta_hours)
+    return s
+
+
+def _make_key(exchange: str = "binance"):
+    k = MagicMock()
+    k.exchange = exchange
+    return k
+
+
+def _make_balance_obj(asset: str, free: float = 1.0):
+    b = MagicMock()
+    b.asset = asset
+    b.free = free
+    b.locked = 0.0
+    b.total = free
+    return b
+
+
+# ---------------------------------------------------------------------------
+# (a) History endpoint returns stored snapshots filtered by days, scoped to owner
+# ---------------------------------------------------------------------------
+
+class TestHistoryEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_snapshots_in_order(self):
+        """Snapshots within the requested day window are returned oldest-first."""
+        snap1 = _make_snapshot(total_usd=100.0, delta_hours=10)
+        snap2 = _make_snapshot(total_usd=200.0, delta_hours=2)
+
+        profile = _make_profile(profile_id=1, owner_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+
+        mock_scalars = MagicMock()
+        mock_scalars.scalars.return_value.all.return_value = [snap1, snap2]
+        db.execute = AsyncMock(return_value=mock_scalars)
+
+        result = await portfolio_history(
+            profile_id=1, days=30, db=db, current_user=_make_user(1)
+        )
+        assert len(result) == 2
+        assert result[0].total_usd == 100.0
+        assert result[1].total_usd == 200.0
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_missing_profile(self):
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc:
+            await portfolio_history(profile_id=999, days=30, db=db, current_user=_make_user(1))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_returns_403_for_wrong_owner(self):
+        profile = _make_profile(profile_id=1, owner_id=99)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+
+        with pytest.raises(HTTPException) as exc:
+            await portfolio_history(profile_id=1, days=30, db=db, current_user=_make_user(1))
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_empty_history_returns_empty_list(self):
+        profile = _make_profile(profile_id=1, owner_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=mock_result)
+
+        result = await portfolio_history(profile_id=1, days=30, db=db, current_user=_make_user(1))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# (b) Throttle: two computes within one hour produce only one snapshot
+# ---------------------------------------------------------------------------
+
+class TestSnapshotThrottle:
+    @pytest.mark.asyncio
+    async def test_no_insert_when_recent_snapshot_exists(self):
+        """If a snapshot was written less than 1h ago, no new one is created."""
+        recent = _make_snapshot(delta_hours=0)  # just now
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = recent
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=mock_result)
+
+        await _maybe_save_snapshot(profile_id=1, total_usd=500.0, db=db)
+
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inserts_when_no_recent_snapshot(self):
+        """If no recent snapshot exists, a new one is inserted."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = None  # no recent
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=mock_result)
+        db.add = MagicMock()  # db.add is sync in SQLAlchemy async sessions
+
+        await _maybe_save_snapshot(profile_id=1, total_usd=500.0, db=db)
+
+        db.add.assert_called_once()
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_only_one_snapshot_per_hour_via_get_portfolio(self):
+        """get_portfolio called twice quickly should result in at most one add."""
+        add_calls = []
+
+        mock_result = MagicMock()
+        # First call: no recent snapshot → insert
+        # Second call: recent snapshot exists → skip
+        mock_result.scalars.return_value.first.side_effect = [None, _make_snapshot()]
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=mock_result)
+        db.add = MagicMock(side_effect=lambda x: add_calls.append(x))
+
+        async def mock_fetch(key, http_client=None):
+            return (key.exchange, [_make_balance_obj("BTC")])
+
+        with patch("app.services.portfolio_service._fetch_exchange_balance", side_effect=mock_fetch):
+            with patch("app.services.portfolio_service.get_usd_prices", return_value={"BTC": 50000.0}):
+                await get_portfolio(1, "test", [_make_key()], db=db)
+                await get_portfolio(1, "test", [_make_key()], db=db)
+
+        assert len(add_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# (c) Snapshot write failure does not break portfolio response
+# ---------------------------------------------------------------------------
+
+class TestSnapshotFailureSafety:
+    @pytest.mark.asyncio
+    async def test_portfolio_still_returns_on_snapshot_failure(self):
+        """A DB error during snapshot write must not raise or block the response."""
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=Exception("DB connection lost"))
+
+        async def mock_fetch(key, http_client=None):
+            return (key.exchange, [_make_balance_obj("ETH", free=2.0)])
+
+        with patch("app.services.portfolio_service._fetch_exchange_balance", side_effect=mock_fetch):
+            with patch("app.services.portfolio_service.get_usd_prices", return_value={"ETH": 3000.0}):
+                result = await get_portfolio(1, "test", [_make_key("binance")], db=db)
+
+        assert result is not None
+        assert result.total_usd == pytest.approx(6000.0)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_failure_logs_warning(self):
+        """A snapshot failure should be logged as a warning."""
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("app.services.portfolio_service.logger") as mock_logger:
+            await _maybe_save_snapshot(profile_id=5, total_usd=100.0, db=db)
+            mock_logger.warning.assert_called_once()
+            call_kwargs = mock_logger.warning.call_args
+            assert "portfolio_snapshot_write_failed" in call_kwargs[0]
+
+
+# ---------------------------------------------------------------------------
+# (d) days param cap/validation
+# ---------------------------------------------------------------------------
+
+class TestDaysParam:
+    @pytest.mark.asyncio
+    async def test_days_defaults_to_30(self):
+        """Default days value should be 30."""
+        profile = _make_profile()
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=mock_result)
+
+        # days=30 (default) should work fine
+        result = await portfolio_history(profile_id=1, days=30, db=db, current_user=_make_user(1))
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_days_max_allowed_is_365(self):
+        """days=365 should be accepted."""
+        profile = _make_profile()
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(return_value=mock_result)
+
+        result = await portfolio_history(profile_id=1, days=365, db=db, current_user=_make_user(1))
+        assert result == []
+
+    def test_days_query_param_default_and_bounds(self):
+        """Verify the Query annotation has correct default and bounds."""
+        import inspect
+
+        from app.api.v1.history import portfolio_history as ph
+
+        sig = inspect.signature(ph)
+        days_param = sig.parameters["days"]
+        q = days_param.default
+        assert q.default == 30
+        # FastAPI stores constraints in metadata as annotated-types objects
+        meta_strs = str(q.metadata)
+        assert "1" in meta_strs   # ge=1
+        assert "365" in meta_strs  # le=365


### PR DESCRIPTION
## Summary

- **PortfolioSnapshot model** (`backend/app/models/portfolio_snapshot.py`): `id PK`, `profile_id FK→profiles (CASCADE, indexed)`, `total_usd Float`, `created_at DateTime(tz) server_default now()`
- **Alembic migration 010** creates `portfolio_snapshots` table with composite index on `(profile_id, created_at)`
- **Snapshot-on-fetch** in `portfolio_service.get_portfolio`: after computing `total_usd` a snapshot is persisted via `_maybe_save_snapshot`, throttled to at most once per hour per profile; wrapped in `try/except` so failures only log a warning and never block the portfolio response
- **New endpoint** `GET /api/v1/profiles/{profile_id}/history?days=30` (cap 365): returns `list[{created_at, total_usd}]` oldest→newest, scoped to the authenticated owner
- **`PortfolioHistoryPoint` pydantic schema** added to `app/schemas/portfolio.py` with `ConfigDict(from_attributes=True)`

## Test plan

- [ ] `test_portfolio_history.py` — 12 new tests covering history filtering, ownership scoping, 1h throttle, failure safety, and query param validation
- [ ] `uv run pytest -q` → 187 passed (was 175)
- [ ] `uv run ruff check` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)