### PR TITLE
feat(frontend): portfolio value history chart on dashboard

### DIFF
--- a/frontend/src/__tests__/portfoliohistorychart.test.tsx
+++ b/frontend/src/__tests__/portfoliohistorychart.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { PortfolioSnapshot } from "@/lib/types";
+
+// ── SWR hook mock ─────────────────────────────────────────────────────────────
+
+let mockHookReturn: {
+  history: PortfolioSnapshot[] | undefined;
+  error: Error | undefined;
+  isLoading: boolean;
+} = { history: undefined, error: undefined, isLoading: false };
+
+// Track which URL was last requested via the hook
+let lastRequestedDays: number | undefined;
+
+vi.mock("@/hooks/usePortfolio", () => ({
+  usePortfolioHistory: (profileId: number | null, days: number) => {
+    lastRequestedDays = days;
+    return mockHookReturn;
+  },
+}));
+
+// ── recharts mock (mirrors how other chart tests handle it) ──────────────────
+// recharts uses ResizeObserver + SVG internals that aren't available in jsdom;
+// mock the heavy rendering components while preserving data flow.
+
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    AreaChart: ({ children, data }: { children: React.ReactNode; data: PortfolioSnapshot[] }) => (
+      <div data-testid="area-chart" data-length={data?.length ?? 0}>
+        {children}
+      </div>
+    ),
+    Area: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    defs: () => null,
+    linearGradient: () => null,
+    stop: () => null,
+  };
+});
+
+// Import component after mocks
+import PortfolioHistoryChart from "@/components/PortfolioHistoryChart";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const makeSnapshot = (days_ago: number): PortfolioSnapshot => {
+  const d = new Date("2026-06-06T00:00:00Z");
+  d.setDate(d.getDate() - days_ago);
+  return {
+    created_at: d.toISOString(),
+    total_usd: 10000 + days_ago * 100,
+  };
+};
+
+const MOCK_HISTORY: PortfolioSnapshot[] = [
+  makeSnapshot(5),
+  makeSnapshot(4),
+  makeSnapshot(3),
+  makeSnapshot(2),
+  makeSnapshot(1),
+  makeSnapshot(0),
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PortfolioHistoryChart", () => {
+  beforeEach(() => {
+    mockHookReturn = { history: undefined, error: undefined, isLoading: false };
+    lastRequestedDays = undefined;
+  });
+
+  it("renders chart when history data is available", () => {
+    mockHookReturn = { history: MOCK_HISTORY, error: undefined, isLoading: false };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    expect(screen.getByRole("img", { name: /portfolio value over time/i })).toBeInTheDocument();
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+  });
+
+  it("shows empty state when history has fewer than 2 data points", () => {
+    mockHookReturn = { history: [], error: undefined, isLoading: false };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/not enough history yet/i)).toBeInTheDocument();
+  });
+
+  it("shows loading state while fetching", () => {
+    mockHookReturn = { history: undefined, error: undefined, isLoading: true };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    expect(screen.getByRole("status", { name: /loading portfolio history/i })).toBeInTheDocument();
+  });
+
+  it("shows error alert when the hook returns an error", () => {
+    mockHookReturn = {
+      history: undefined,
+      error: new Error("Network failure"),
+      isLoading: false,
+    };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert.textContent).toMatch(/network failure/i);
+  });
+
+  it("shows a hint when no profile is selected", () => {
+    render(<PortfolioHistoryChart profileId={null} />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/select a profile/i)).toBeInTheDocument();
+  });
+
+  it("range toggle 7D requests days=7", () => {
+    mockHookReturn = { history: MOCK_HISTORY, error: undefined, isLoading: false };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    const btn7 = screen.getByRole("button", { name: "7D" });
+    fireEvent.click(btn7);
+
+    expect(lastRequestedDays).toBe(7);
+  });
+
+  it("range toggle 90D requests days=90", () => {
+    mockHookReturn = { history: MOCK_HISTORY, error: undefined, isLoading: false };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    const btn90 = screen.getByRole("button", { name: "90D" });
+    fireEvent.click(btn90);
+
+    expect(lastRequestedDays).toBe(90);
+  });
+
+  it("default range is 30D", () => {
+    mockHookReturn = { history: MOCK_HISTORY, error: undefined, isLoading: false };
+
+    render(<PortfolioHistoryChart profileId={1} />);
+
+    // Default: hook should have been called with days=30
+    expect(lastRequestedDays).toBe(30);
+    const btn30 = screen.getByRole("button", { name: "30D" });
+    expect(btn30).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { OnboardingWizard } from "@/components/OnboardingWizard";
 import TradeHistory from "@/components/TradeHistory";
 
 const AllocationChart = dynamic(() => import("@/components/AllocationChart"), { ssr: false });
+const PortfolioHistoryChart = dynamic(() => import("@/components/PortfolioHistoryChart"), { ssr: false });
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -96,6 +97,10 @@ export default function DashboardPage() {
                 ? undefined
                 : (portfolio as PortfolioResponse)?.cached
             }
+          />
+
+          <PortfolioHistoryChart
+            profileId={typeof selectedProfileId === "number" ? selectedProfileId : null}
           />
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/frontend/src/components/PortfolioHistoryChart.tsx
+++ b/frontend/src/components/PortfolioHistoryChart.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { usePortfolioHistory } from "@/hooks/usePortfolio";
+import type { PortfolioSnapshot } from "@/lib/types";
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+function formatShortDate(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(
+    new Date(iso)
+  );
+}
+
+function formatFullDate(iso: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(iso));
+}
+
+function formatCompactUsd(value: number): string {
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `$${(value / 1_000).toFixed(1)}k`;
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(value);
+}
+
+function formatFullUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+// ── Custom Tooltip ────────────────────────────────────────────────────────────
+
+interface TooltipPayloadItem {
+  value: number;
+  payload: { created_at: string; total_usd: number };
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}
+
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const item = payload[0];
+  return (
+    <div
+      style={{
+        backgroundColor: "#111827",
+        border: "1px solid #374151",
+        borderRadius: "8px",
+        padding: "8px 12px",
+        fontSize: "13px",
+      }}
+    >
+      <p className="text-gray-400 text-xs">{formatFullDate(item.payload.created_at)}</p>
+      <p className="text-white font-semibold mt-0.5">{formatFullUsd(item.value)}</p>
+    </div>
+  );
+}
+
+// ── Range Toggle ──────────────────────────────────────────────────────────────
+
+const RANGES: { label: string; days: number }[] = [
+  { label: "7D", days: 7 },
+  { label: "30D", days: 30 },
+  { label: "90D", days: 90 },
+];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface PortfolioHistoryChartProps {
+  profileId: number | null;
+}
+
+export default function PortfolioHistoryChart({ profileId }: PortfolioHistoryChartProps) {
+  const [days, setDays] = useState<number>(30);
+  const { history, error, isLoading } = usePortfolioHistory(profileId, days);
+
+  if (profileId == null) {
+    return (
+      <div
+        role="status"
+        className="bg-gray-900 border border-gray-800 rounded-xl p-6 text-gray-400 text-sm text-center"
+      >
+        Select a profile to view portfolio history.
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-widest">
+          Portfolio Value History
+        </h3>
+        <div className="flex gap-1" role="group" aria-label="Date range">
+          {RANGES.map(({ label, days: d }) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              aria-pressed={days === d}
+              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                days === d
+                  ? "bg-blue-600 text-white"
+                  : "text-gray-400 hover:text-white hover:bg-gray-700"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* States */}
+      {isLoading && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="Loading portfolio history"
+          className="h-48 flex items-center justify-center"
+        >
+          <div className="h-48 w-full bg-gray-800 rounded animate-pulse" />
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div
+          role="alert"
+          className="h-48 flex items-center justify-center text-red-300 text-sm"
+        >
+          Failed to load portfolio history: {(error as Error).message ?? String(error)}
+        </div>
+      )}
+
+      {!isLoading && !error && history && history.length < 2 && (
+        <div
+          role="status"
+          className="h-48 flex items-center justify-center text-gray-500 text-sm text-center px-4"
+        >
+          Not enough history yet — value is recorded as you use the app.
+        </div>
+      )}
+
+      {!isLoading && !error && history && history.length >= 2 && (
+        <div role="img" aria-label="Portfolio value over time area chart">
+          <ResponsiveContainer width="100%" height={200}>
+            <AreaChart data={history as PortfolioSnapshot[]}>
+              <defs>
+                <linearGradient id="histGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.25} />
+                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" vertical={false} />
+              <XAxis
+                dataKey="created_at"
+                tickFormatter={formatShortDate}
+                tick={{ fontSize: 11, fill: "#6b7280" }}
+                axisLine={false}
+                tickLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tickFormatter={formatCompactUsd}
+                tick={{ fontSize: 11, fill: "#6b7280" }}
+                axisLine={false}
+                tickLine={false}
+                width={60}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="total_usd"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                fill="url(#histGradient)"
+                dot={false}
+                activeDot={{ r: 4, fill: "#3b82f6" }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr'
-import type { TradeOrder } from '@/lib/types'
+import type { TradeOrder, PortfolioSnapshot } from '@/lib/types'
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
 
@@ -19,6 +19,16 @@ export function usePortfolio(profileId: number) {
 export function useProfiles() {
   const { data, error, isLoading } = useSWR(`${BASE_URL}/api/v1/profiles/`, fetcher)
   return { profiles: data, error, isLoading }
+}
+
+export function usePortfolioHistory(profileId: number | null, days: number = 30) {
+  const { data, error, isLoading } = useSWR<PortfolioSnapshot[]>(
+    profileId != null
+      ? `${BASE_URL}/api/v1/profiles/${profileId}/history?days=${days}`
+      : null,
+    fetcher
+  )
+  return { history: data, error, isLoading }
 }
 
 export function useTradeHistory(profileId: number | null) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -132,6 +132,11 @@ export interface SharedExchange {
   total_usd: number | null;
 }
 
+export interface PortfolioSnapshot {
+  created_at: string;
+  total_usd: number;
+}
+
 export interface SharedPortfolioView {
   token: string;
   profile_name: string;


### PR DESCRIPTION
## Summary
- Adds `usePortfolioHistory(profileId, days)` SWR hook calling `GET /api/v1/profiles/{id}/history?days=N` with JWT auth (same pattern as `useTradeHistory`)
- Adds `PortfolioHistoryChart` component: recharts `AreaChart` with 7/30/90-day range toggle, compact Y-axis (`$12.3k`), short X-axis date labels (`Jun 5`), full-detail tooltip, and loading/empty/error states with `role=status`/`role=alert` matching `TradeHistory` a11y conventions
- Surfaces the chart on the dashboard above `AllocationChart`; hidden (shows pick-a-profile hint) when aggregate view is selected — same pattern as `TradeHistory`

## Test plan
- [ ] `npx tsc --noEmit` — passes (0 errors)
- [ ] `CI=1 npx vitest run` — 46 tests pass (8 new in `portfoliohistorychart.test.tsx`: renders with data, empty state, loading, error, no-profile hint, 7D/90D range toggle changes days param, default 30D)
- [ ] `CI=1 npx next build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)