### PR TITLE
feat(backend): realized P&L + avg cost basis from CoinHQ trade history

### DIFF
--- a/backend/app/api/v1/pnl.py
+++ b/backend/app/api/v1/pnl.py
@@ -1,0 +1,51 @@
+"""
+GET /api/v1/profiles/{profile_id}/pnl
+
+Returns realized P&L and average cost basis per asset, computed from the
+filled TradeOrder records stored by CoinHQ using the average-cost (AVCO)
+method.
+
+IMPORTANT — partial data:
+    These figures reflect ONLY trades executed through CoinHQ.  Holdings
+    purchased or sold directly on the exchange (outside CoinHQ) are not
+    known, so avg_cost and realized_pnl_usd are partial estimates.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.models.profile import Profile
+from app.models.user import User
+from app.schemas.pnl import ProfilePnLResponse
+from app.services.pnl_service import compute_profile_pnl
+
+router = APIRouter(prefix="/profiles", tags=["pnl"])
+
+
+@router.get(
+    "/{profile_id}/pnl",
+    response_model=ProfilePnLResponse,
+    summary="Realized P&L and average cost basis (CoinHQ trades only)",
+    description=(
+        "Returns per-asset realized P&L and average cost basis computed from "
+        "filled orders recorded by CoinHQ using the average-cost (AVCO) method. "
+        "**Partial data**: trades executed directly on the exchange outside "
+        "CoinHQ are not captured, so figures may understate true cost basis "
+        "and realized gains/losses."
+    ),
+)
+async def get_profile_pnl(
+    profile_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ProfilePnLResponse:
+    """Owner-scoped P&L endpoint — returns 404 if profile missing, 403 if not owner."""
+    profile = await db.get(Profile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    if profile.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    return await compute_profile_pnl(profile_id=profile_id, db=db)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1 import admin, auth, history, keys, portfolio, profiles, share, trade, waitlist
+from app.api.v1 import admin, auth, history, keys, pnl, portfolio, profiles, share, trade, waitlist
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(auth.router)
 router.include_router(profiles.router)
+router.include_router(pnl.router)
 router.include_router(keys.router)
 router.include_router(portfolio.router)
 router.include_router(history.router)

--- a/backend/app/schemas/pnl.py
+++ b/backend/app/schemas/pnl.py
@@ -1,0 +1,69 @@
+"""
+Pydantic schemas for the realized P&L / average cost basis endpoint.
+
+IMPORTANT SEMANTIC NOTE — partial data:
+    All figures here reflect ONLY trades executed THROUGH CoinHQ.
+    Holdings bought or sold directly on the exchange (outside CoinHQ) are
+    invisible to this calculation, so avg_cost and realized_pnl_usd are
+    partial estimates. The UI must make this limitation clear to the user.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AssetPnL(BaseModel):
+    """Realized P&L and cost-basis summary for a single base asset.
+
+    Computed using the average-cost (AVCO) method over all filled CoinHQ
+    orders, processed in chronological order.  Figures are partial — see
+    module docstring.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    base_asset: str = Field(
+        description="The base asset ticker, e.g. 'BTC'.",
+    )
+    current_qty: float = Field(
+        description=(
+            "Net quantity still held according to CoinHQ trade history "
+            "(buys minus sells, clamped to ≥0)."
+        ),
+    )
+    avg_cost: float | None = Field(
+        default=None,
+        description=(
+            "Average cost per unit in USD for the current open position. "
+            "Null when current_qty is zero (no open position)."
+        ),
+    )
+    realized_pnl_usd: float = Field(
+        description=(
+            "Total realized profit/loss in USD from completed sells recorded "
+            "in CoinHQ.  Positive = profit, negative = loss.  Partial — see "
+            "module docstring."
+        ),
+    )
+    total_bought_usd: float = Field(
+        description="Sum of usd_value across all filled buy orders for this asset.",
+    )
+    total_sold_usd: float = Field(
+        description="Sum of usd_value across all filled sell orders for this asset.",
+    )
+    buy_count: int = Field(description="Number of filled buy orders included.")
+    sell_count: int = Field(description="Number of filled sell orders included.")
+
+
+class ProfilePnLResponse(BaseModel):
+    """Response for GET /api/v1/profiles/{profile_id}/pnl.
+
+    IMPORTANT: figures reflect ONLY trades executed through CoinHQ.
+    Holdings purchased or sold directly on the exchange are not captured.
+    """
+
+    assets: list[AssetPnL] = Field(
+        description="Per-asset P&L breakdown, one entry per traded asset.",
+    )
+    total_realized_pnl_usd: float = Field(
+        description="Sum of realized_pnl_usd across all assets.",
+    )

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -1,0 +1,118 @@
+"""
+Realized P&L and average cost-basis service.
+
+Uses the average-cost (AVCO) method applied to filled TradeOrder records in
+chronological order.
+
+IMPORTANT — partial data:
+    Only orders placed through CoinHQ are visible.  Holdings acquired or sold
+    directly on the exchange are unknown, so the computed avg_cost and
+    realized_pnl_usd are partial.  Callers and the UI must communicate this
+    limitation to end-users.
+
+Edge case — over-sell:
+    If a sell order's amount exceeds the qty currently tracked in CoinHQ
+    (because some buys happened outside CoinHQ), the sell is clamped to the
+    tracked qty.  This prevents negative holdings.  The P&L is computed only
+    on the clamped qty; the remainder is silently ignored.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trade_order import TradeOrder
+from app.schemas.pnl import AssetPnL, ProfilePnLResponse
+
+
+@dataclass
+class _AssetState:
+    """Mutable accumulator for one (profile, base_asset) pair."""
+
+    qty: float = 0.0
+    cost_basis_total: float = 0.0  # USD cost of current open position
+    realized_pnl: float = 0.0
+    total_bought_usd: float = 0.0
+    total_sold_usd: float = 0.0
+    buy_count: int = 0
+    sell_count: int = 0
+
+
+async def compute_profile_pnl(
+    profile_id: int,
+    db: AsyncSession,
+) -> ProfilePnLResponse:
+    """Compute realized P&L and average cost basis for *profile_id*.
+
+    Returns a :class:`ProfilePnLResponse` with one :class:`AssetPnL` entry
+    per asset that has at least one filled trade.  Assets are returned sorted
+    alphabetically for stable ordering.
+
+    Only ``status == 'filled'`` orders with a non-null ``amount`` are
+    processed.  Orders are processed in ``created_at`` ascending order so
+    that the AVCO math is deterministic.
+    """
+    result = await db.execute(
+        select(TradeOrder)
+        .where(
+            TradeOrder.profile_id == profile_id,
+            TradeOrder.status == "filled",
+            TradeOrder.amount.is_not(None),
+        )
+        .order_by(TradeOrder.created_at.asc())
+    )
+    orders = result.scalars().all()
+
+    states: dict[str, _AssetState] = defaultdict(_AssetState)
+
+    for order in orders:
+        asset = order.base_asset.upper()
+        s = states[asset]
+        amount: float = order.amount  # type: ignore[assignment]  # guarded by IS NOT NULL
+        usd_value: float = order.usd_value
+
+        if order.side == "buy":
+            s.qty += amount
+            s.cost_basis_total += usd_value
+            s.total_bought_usd += usd_value
+            s.buy_count += 1
+
+        elif order.side == "sell":
+            # Clamp sell qty to what we track — see module docstring.
+            sell_qty = min(amount, s.qty)
+
+            if sell_qty > 0 and s.qty > 0:
+                sell_price_per_unit = usd_value / amount
+                avg_cost = s.cost_basis_total / s.qty
+                s.realized_pnl += sell_qty * (sell_price_per_unit - avg_cost)
+                s.cost_basis_total -= sell_qty * avg_cost
+                s.qty -= sell_qty
+
+            s.total_sold_usd += usd_value
+            s.sell_count += 1
+
+    asset_pnls: list[AssetPnL] = []
+    for asset, s in sorted(states.items()):
+        avg_cost: float | None = (
+            s.cost_basis_total / s.qty if s.qty > 1e-12 else None
+        )
+        asset_pnls.append(
+            AssetPnL(
+                base_asset=asset,
+                current_qty=s.qty,
+                avg_cost=avg_cost,
+                realized_pnl_usd=s.realized_pnl,
+                total_bought_usd=s.total_bought_usd,
+                total_sold_usd=s.total_sold_usd,
+                buy_count=s.buy_count,
+                sell_count=s.sell_count,
+            )
+        )
+
+    total_realized = sum(a.realized_pnl_usd for a in asset_pnls)
+    return ProfilePnLResponse(
+        assets=asset_pnls,
+        total_realized_pnl_usd=total_realized,
+    )

--- a/backend/tests/test_pnl.py
+++ b/backend/tests/test_pnl.py
@@ -1,0 +1,279 @@
+"""
+Tests for the realized P&L / average cost-basis feature.
+
+Covers:
+  (a) buy-then-sell-higher  → positive realized P&L, correct avg_cost
+  (b) buy-then-sell-lower   → negative realized P&L
+  (c) multiple buys at different prices, then partial sell → AVCO math
+  (d) failed/pending/null-amount orders are ignored
+  (e) sell with no / insufficient prior buys → no crash, qty clamped ≥ 0
+  (f) endpoint owner-scoping → 403/404
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_KEY", "dGVzdC1lbmNyeXB0aW9uLWtleS0zMi1ieXRlc3h4")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-for-unit-tests-only")
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.pnl import get_profile_pnl
+from app.services.pnl_service import compute_profile_pnl
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_order(
+    *,
+    side: str,
+    usd_value: float,
+    amount: float | None,
+    status: str = "filled",
+    base_asset: str = "BTC",
+    profile_id: int = 1,
+    created_at=None,
+):
+    """Return a lightweight MagicMock that looks like a TradeOrder row."""
+    import datetime
+
+    order = MagicMock()
+    order.profile_id = profile_id
+    order.base_asset = base_asset
+    order.side = side
+    order.usd_value = usd_value
+    order.amount = amount
+    order.status = status
+    order.created_at = created_at or datetime.datetime(2024, 1, 1)
+    return order
+
+
+def _db_returning(orders: list):
+    """AsyncMock db whose execute() returns a scalars().all() == orders."""
+    scalars_mock = MagicMock()
+    scalars_mock.all = MagicMock(return_value=orders)
+    result_mock = MagicMock()
+    result_mock.scalars = MagicMock(return_value=scalars_mock)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result_mock)
+    return db
+
+
+def _make_profile(profile_id: int = 1, owner_id: int = 1):
+    p = MagicMock()
+    p.id = profile_id
+    p.user_id = owner_id
+    return p
+
+
+def _make_user(user_id: int = 1):
+    u = MagicMock()
+    u.id = user_id
+    return u
+
+
+# ── service-level tests ────────────────────────────────────────────────────────
+
+
+class TestComputeProfilePnL:
+    # (a) buy low, sell high → positive realized P&L
+    @pytest.mark.asyncio
+    async def test_buy_then_sell_higher_positive_pnl(self):
+        orders = [
+            _make_order(side="buy",  usd_value=10_000.0, amount=1.0),   # avg_cost = 10_000
+            _make_order(side="sell", usd_value=12_000.0, amount=1.0),   # sell @ 12_000
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        assert len(resp.assets) == 1
+        a = resp.assets[0]
+        assert a.base_asset == "BTC"
+        assert a.realized_pnl_usd == pytest.approx(2_000.0)
+        assert a.current_qty == pytest.approx(0.0, abs=1e-9)
+        assert a.avg_cost is None                  # no open position
+        assert a.buy_count == 1
+        assert a.sell_count == 1
+        assert a.total_bought_usd == pytest.approx(10_000.0)
+        assert a.total_sold_usd == pytest.approx(12_000.0)
+        assert resp.total_realized_pnl_usd == pytest.approx(2_000.0)
+
+    # (b) sell below cost → negative P&L
+    @pytest.mark.asyncio
+    async def test_buy_then_sell_lower_negative_pnl(self):
+        orders = [
+            _make_order(side="buy",  usd_value=10_000.0, amount=1.0),
+            _make_order(side="sell", usd_value=8_000.0,  amount=1.0),
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        a = resp.assets[0]
+        assert a.realized_pnl_usd == pytest.approx(-2_000.0)
+        assert resp.total_realized_pnl_usd == pytest.approx(-2_000.0)
+
+    # (c) multiple buys at different prices, then partial sell → AVCO math
+    @pytest.mark.asyncio
+    async def test_multiple_buys_partial_sell_avco(self):
+        """
+        Buy 1 BTC @ $10 000  →  cost_basis = $10 000, qty = 1
+        Buy 1 BTC @ $20 000  →  cost_basis = $30 000, qty = 2
+        avg_cost              = $15 000 / BTC
+        Sell 0.5 BTC @ $18 000 / BTC (usd_value = $9 000)
+          realized = 0.5 * (18_000 - 15_000) = $1 500
+          remaining qty = 1.5,  cost_basis = 30_000 - 0.5*15_000 = 22_500
+          avg_cost unchanged = 22_500 / 1.5 = 15_000
+        """
+        orders = [
+            _make_order(side="buy",  usd_value=10_000.0, amount=1.0),
+            _make_order(side="buy",  usd_value=20_000.0, amount=1.0),
+            _make_order(side="sell", usd_value=9_000.0,  amount=0.5),
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        a = resp.assets[0]
+        assert a.realized_pnl_usd == pytest.approx(1_500.0)
+        assert a.current_qty      == pytest.approx(1.5)
+        assert a.avg_cost         == pytest.approx(15_000.0)
+        assert a.buy_count  == 2
+        assert a.sell_count == 1
+        assert a.total_bought_usd == pytest.approx(30_000.0)
+        assert a.total_sold_usd   == pytest.approx(9_000.0)
+
+    # (d) failed / pending / null-amount orders are silently ignored
+    @pytest.mark.asyncio
+    async def test_non_filled_and_null_amount_orders_ignored(self):
+        # The DB query filters these out; we simulate the service receiving
+        # only the filtered slice (empty list here).
+        db = _db_returning([])
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        assert resp.assets == []
+        assert resp.total_realized_pnl_usd == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_failed_order_not_counted(self):
+        # If DB filtering somehow leaks a non-filled order, make sure the
+        # service state reflects only what the service processes.
+        # Here we simulate only filled orders being passed through.
+        orders = [
+            _make_order(side="buy", usd_value=1_000.0, amount=0.1),
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        a = resp.assets[0]
+        assert a.buy_count == 1
+        assert a.current_qty == pytest.approx(0.1)
+
+    # (e) sell with no / insufficient prior buys → clamped, no crash
+    @pytest.mark.asyncio
+    async def test_sell_with_no_prior_buys_no_crash(self):
+        """Sell 1 BTC with zero tracked position → clamped to 0; qty stays 0."""
+        orders = [
+            _make_order(side="sell", usd_value=10_000.0, amount=1.0),
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        a = resp.assets[0]
+        assert a.current_qty      == pytest.approx(0.0, abs=1e-9)
+        assert a.realized_pnl_usd == pytest.approx(0.0)
+        assert a.sell_count == 1
+        assert a.avg_cost is None
+
+    @pytest.mark.asyncio
+    async def test_oversell_clamped_no_negative_qty(self):
+        """Buy 0.5, then sell 2.0 → qty clamped to 0 (no negative holdings)."""
+        orders = [
+            _make_order(side="buy",  usd_value=5_000.0, amount=0.5),   # avg = 10_000
+            _make_order(side="sell", usd_value=20_000.0, amount=2.0),  # only 0.5 available
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        a = resp.assets[0]
+        assert a.current_qty >= 0
+        assert a.current_qty == pytest.approx(0.0, abs=1e-9)
+        # P&L computed only on 0.5 BTC sold at 20_000/2.0 = 10_000 /BTC
+        # sell_price_per_unit = 20_000 / 2.0 = 10_000; avg_cost = 10_000
+        # realized = 0.5 * (10_000 - 10_000) = 0
+        assert a.realized_pnl_usd == pytest.approx(0.0)
+
+    # Multi-asset: each asset tracked independently
+    @pytest.mark.asyncio
+    async def test_two_assets_tracked_independently(self):
+        orders = [
+            _make_order(side="buy",  usd_value=10_000.0, amount=1.0, base_asset="BTC"),
+            _make_order(side="buy",  usd_value=3_000.0,  amount=1.0, base_asset="ETH"),
+            _make_order(side="sell", usd_value=12_000.0, amount=1.0, base_asset="BTC"),
+        ]
+        db = _db_returning(orders)
+        resp = await compute_profile_pnl(profile_id=1, db=db)
+
+        assets = {a.base_asset: a for a in resp.assets}
+        assert "BTC" in assets and "ETH" in assets
+        assert assets["BTC"].realized_pnl_usd == pytest.approx(2_000.0)
+        assert assets["ETH"].realized_pnl_usd == pytest.approx(0.0)
+        assert assets["ETH"].current_qty      == pytest.approx(1.0)
+        assert resp.total_realized_pnl_usd    == pytest.approx(2_000.0)
+
+
+# ── endpoint / auth tests ──────────────────────────────────────────────────────
+
+
+class TestGetProfilePnLEndpoint:
+    # (f-i) 404 when profile missing
+    @pytest.mark.asyncio
+    async def test_returns_404_for_missing_profile(self):
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc:
+            await get_profile_pnl(
+                profile_id=999,
+                db=db,
+                current_user=_make_user(1),
+            )
+        assert exc.value.status_code == 404
+
+    # (f-ii) 403 when profile belongs to a different user
+    @pytest.mark.asyncio
+    async def test_returns_403_for_wrong_owner(self):
+        profile = _make_profile(profile_id=1, owner_id=99)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+
+        with pytest.raises(HTTPException) as exc:
+            await get_profile_pnl(
+                profile_id=1,
+                db=db,
+                current_user=_make_user(user_id=1),  # user 1 ≠ owner 99
+            )
+        assert exc.value.status_code == 403
+
+    # (f-iii) owner receives a valid response
+    @pytest.mark.asyncio
+    async def test_owner_receives_pnl_response(self):
+        profile = _make_profile(profile_id=1, owner_id=1)
+
+        # db.get returns the profile; db.execute returns empty orders
+        scalars_mock = MagicMock()
+        scalars_mock.all = MagicMock(return_value=[])
+        result_mock = MagicMock()
+        result_mock.scalars = MagicMock(return_value=scalars_mock)
+
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=profile)
+        db.execute = AsyncMock(return_value=result_mock)
+
+        resp = await get_profile_pnl(
+            profile_id=1,
+            db=db,
+            current_user=_make_user(1),
+        )
+        assert resp.assets == []
+        assert resp.total_realized_pnl_usd == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/profiles/{profile_id}/pnl` — owner-scoped (404 if profile missing, 403 if not owner)
- Computes per-asset realized P&L and average cost basis using the **average-cost (AVCO)** method over all `status=filled`, non-null-amount `TradeOrder` rows in `created_at` order
- Over-sell edge case handled: sell qty clamped to held qty, preventing negative positions
- **Partial-data caveat** documented in module docstrings, Pydantic schema `description` fields, and the OpenAPI endpoint summary — trades executed directly on the exchange are not captured

## Files changed

| File | Role |
|------|------|
| `backend/app/schemas/pnl.py` | Pydantic schemas (`AssetPnL`, `ProfilePnLResponse`) with `ConfigDict` |
| `backend/app/services/pnl_service.py` | AVCO computation service |
| `backend/app/api/v1/pnl.py` | FastAPI router, auth/ownership guard |
| `backend/app/api/v1/router.py` | Register `pnl.router` |
| `backend/tests/test_pnl.py` | 11 new tests |

## Test plan

- [x] `(a)` buy-then-sell-higher → positive realized P&L + correct avg_cost
- [x] `(b)` buy-then-sell-lower → negative realized P&L
- [x] `(c)` multiple buys at different prices, partial sell → exact AVCO math
- [x] `(d)` failed/pending/null-amount orders ignored (DB-filtered + empty-result case)
- [x] `(e)` sell with no/insufficient prior buys → no crash, qty ≥ 0
- [x] `(f)` endpoint 404 (missing profile), 403 (wrong owner), 200 (owner)
- [x] Full suite: `uv run pytest -q` → **198 passed** (was 187)
- [x] `uv run ruff check` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)