### PR TITLE
feat(frontend): realized P&L + cost basis panel on dashboard

### DIFF
--- a/frontend/src/__tests__/realizedpnl.test.tsx
+++ b/frontend/src/__tests__/realizedpnl.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PnlResponse } from "@/lib/types";
+
+// ── Hook mock ─────────────────────────────────────────────────────────────────
+
+let mockHookReturn: {
+  pnl: PnlResponse | undefined;
+  error: Error | undefined;
+  isLoading: boolean;
+} = { pnl: undefined, error: undefined, isLoading: false };
+
+vi.mock("@/hooks/usePortfolio", () => ({
+  useProfilePnl: () => mockHookReturn,
+}));
+
+// Import after mocking
+import RealizedPnL from "@/components/RealizedPnL";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const makePnl = (overrides: Partial<PnlResponse> = {}): PnlResponse => ({
+  total_realized_pnl_usd: 1500.0,
+  assets: [
+    {
+      base_asset: "BTC",
+      current_qty: 1.5,
+      avg_cost: 15000.0,
+      realized_pnl_usd: 1500.0,
+      total_bought_usd: 30000.0,
+      total_sold_usd: 9000.0,
+      buy_count: 2,
+      sell_count: 1,
+    },
+  ],
+  ...overrides,
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("RealizedPnL", () => {
+  beforeEach(() => {
+    mockHookReturn = { pnl: undefined, error: undefined, isLoading: false };
+  });
+
+  it("renders total and per-asset rows from mocked data", () => {
+    mockHookReturn = { pnl: makePnl(), error: undefined, isLoading: false };
+
+    render(<RealizedPnL profileId={1} />);
+
+    // Total P&L shown (appears in header + per-asset row)
+    expect(screen.getAllByText(/\+\$1,500\.00/).length).toBeGreaterThanOrEqual(1);
+    // Asset row
+    expect(screen.getByText("BTC")).toBeInTheDocument();
+    // Avg cost
+    expect(screen.getByText("$15,000.00")).toBeInTheDocument();
+    // Buy/sell count
+    expect(screen.getByText("2B / 1S")).toBeInTheDocument();
+  });
+
+  it("styles positive P&L with green", () => {
+    mockHookReturn = { pnl: makePnl({ total_realized_pnl_usd: 1500 }), error: undefined, isLoading: false };
+
+    render(<RealizedPnL profileId={1} />);
+
+    // The total amount element should have green class
+    const totalEl = screen.getByLabelText(/total realized p&l/i);
+    expect(totalEl.className).toMatch(/green/);
+  });
+
+  it("styles negative P&L with red", () => {
+    const negativePnl = makePnl({
+      total_realized_pnl_usd: -500,
+      assets: [
+        {
+          base_asset: "ETH",
+          current_qty: 2,
+          avg_cost: 2000,
+          realized_pnl_usd: -500,
+          total_bought_usd: 4000,
+          total_sold_usd: 1000,
+          buy_count: 1,
+          sell_count: 1,
+        },
+      ],
+    });
+    mockHookReturn = { pnl: negativePnl, error: undefined, isLoading: false };
+
+    render(<RealizedPnL profileId={1} />);
+
+    const totalEl = screen.getByLabelText(/total realized p&l/i);
+    expect(totalEl.className).toMatch(/red/);
+    // Per-asset pnl cell also red
+    const pnlCells = screen.getAllByText("-$500.00");
+    expect(pnlCells.some((el) => el.className.match(/red/))).toBe(true);
+  });
+
+  it("shows '—' when avg_cost is null", () => {
+    const pnl = makePnl({
+      assets: [
+        {
+          base_asset: "SOL",
+          current_qty: 0,
+          avg_cost: null,
+          realized_pnl_usd: 200,
+          total_bought_usd: 500,
+          total_sold_usd: 700,
+          buy_count: 1,
+          sell_count: 1,
+        },
+      ],
+    });
+    mockHookReturn = { pnl, error: undefined, isLoading: false };
+
+    render(<RealizedPnL profileId={1} />);
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows empty state when assets list is empty", () => {
+    mockHookReturn = {
+      pnl: { total_realized_pnl_usd: 0, assets: [] },
+      error: undefined,
+      isLoading: false,
+    };
+
+    render(<RealizedPnL profileId={1} />);
+
+    expect(screen.getByText(/no completed trades yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows error alert when hook returns an error", () => {
+    mockHookReturn = {
+      pnl: undefined,
+      error: new Error("Server error"),
+      isLoading: false,
+    };
+
+    render(<RealizedPnL profileId={1} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert.textContent).toMatch(/server error/i);
+  });
+
+  it("shows the 'CoinHQ trades only' disclaimer caption", () => {
+    mockHookReturn = { pnl: makePnl(), error: undefined, isLoading: false };
+
+    render(<RealizedPnL profileId={1} />);
+
+    expect(screen.getByText(/coinHQ trades only/i)).toBeInTheDocument();
+    expect(screen.getByText(/excludes positions traded directly on exchanges/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { PortfolioSkeleton } from "@/components/SkeletonCard";
 import { Navigation } from "@/components/Navigation";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
 import TradeHistory from "@/components/TradeHistory";
+import RealizedPnL from "@/components/RealizedPnL";
 
 const AllocationChart = dynamic(() => import("@/components/AllocationChart"), { ssr: false });
 const PortfolioHistoryChart = dynamic(() => import("@/components/PortfolioHistoryChart"), { ssr: false });
@@ -107,6 +108,14 @@ export default function DashboardPage() {
             <AllocationChart exchanges={exchanges} />
             <ExchangeList exchanges={exchanges} />
           </div>
+        </div>
+      )}
+
+      {/* Realized P&L */}
+      {!loading && portfolio && (
+        <div className="mt-8">
+          <h2 className="text-lg font-semibold text-white mb-2">Realized P&amp;L</h2>
+          <RealizedPnL profileId={typeof selectedProfileId === "number" ? selectedProfileId : null} />
         </div>
       )}
 

--- a/frontend/src/components/RealizedPnL.tsx
+++ b/frontend/src/components/RealizedPnL.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import type { PnlAsset } from "@/lib/types";
+import { useProfilePnl } from "@/hooks/usePortfolio";
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatQty(value: number): string {
+  return value.toLocaleString("en-US", { maximumFractionDigits: 6 });
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function PnlValue({ value }: { value: number }) {
+  const positive = value >= 0;
+  return (
+    <span className={positive ? "text-green-400 font-medium" : "text-red-400 font-medium"}>
+      {positive ? "+" : ""}
+      {formatUsd(value)}
+    </span>
+  );
+}
+
+function AssetRow({ asset }: { asset: PnlAsset }) {
+  return (
+    <tr className="transition-colors hover:bg-gray-800/40">
+      <td className="px-4 py-3 font-medium text-white">{asset.base_asset}</td>
+      <td className="px-4 py-3 text-gray-300">{formatQty(asset.current_qty)}</td>
+      <td className="px-4 py-3 text-gray-300">
+        {asset.avg_cost != null ? formatUsd(asset.avg_cost) : "—"}
+      </td>
+      <td className="px-4 py-3">
+        <PnlValue value={asset.realized_pnl_usd} />
+      </td>
+      <td className="px-4 py-3 text-gray-400 text-sm">
+        {asset.buy_count}B / {asset.sell_count}S
+      </td>
+    </tr>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface RealizedPnLProps {
+  profileId: number | null;
+}
+
+export default function RealizedPnL({ profileId }: RealizedPnLProps) {
+  const { pnl, error, isLoading } = useProfilePnl(profileId);
+
+  if (profileId == null) {
+    return (
+      <div
+        role="status"
+        className="mt-4 p-4 bg-gray-800/50 rounded-lg text-gray-400 text-sm text-center"
+      >
+        Select a profile to view realized P&amp;L.
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="Loading realized P&L"
+        className="mt-4 space-y-2"
+      >
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-10 bg-gray-800 rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="mt-4 p-4 bg-red-900/30 border border-red-700 rounded-lg text-red-300 text-sm"
+      >
+        Failed to load realized P&amp;L: {(error as Error).message ?? String(error)}
+      </div>
+    );
+  }
+
+  if (!pnl || pnl.assets.length === 0) {
+    return (
+      <div
+        role="status"
+        className="mt-4 p-8 text-center text-gray-500 text-sm bg-gray-800/30 rounded-lg"
+      >
+        No completed trades yet.
+      </div>
+    );
+  }
+
+  const total = pnl.total_realized_pnl_usd;
+  const positive = total >= 0;
+
+  return (
+    <div className="mt-4">
+      {/* Header: total realized P&L */}
+      <div className="flex items-baseline gap-3 mb-1">
+        <span
+          className={`text-2xl font-bold tabular-nums ${
+            positive ? "text-green-400" : "text-red-400"
+          }`}
+          aria-label={`Total realized P&L: ${formatUsd(total)}`}
+        >
+          {positive ? "+" : ""}
+          {formatUsd(total)}
+        </span>
+      </div>
+      <p className="text-xs text-gray-500 mb-4">
+        Realized P&amp;L &middot; CoinHQ trades only (excludes positions traded directly on
+        exchanges)
+      </p>
+
+      {/* Per-asset table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-700">
+        <table className="min-w-full divide-y divide-gray-700 text-sm">
+          <thead className="bg-gray-800/60">
+            <tr>
+              {["Asset", "Qty (CoinHQ)", "Avg Cost", "Realized P&L", "Trades"].map((h) => (
+                <th
+                  key={h}
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700/50">
+            {pnl.assets.map((asset) => (
+              <AssetRow key={asset.base_asset} asset={asset} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr'
-import type { TradeOrder, PortfolioSnapshot } from '@/lib/types'
+import type { TradeOrder, PortfolioSnapshot, PnlResponse } from '@/lib/types'
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
 
@@ -29,6 +29,14 @@ export function usePortfolioHistory(profileId: number | null, days: number = 30)
     fetcher
   )
   return { history: data, error, isLoading }
+}
+
+export function useProfilePnl(profileId: number | null) {
+  const { data, error, isLoading } = useSWR<PnlResponse>(
+    profileId != null ? `${BASE_URL}/api/v1/profiles/${profileId}/pnl` : null,
+    fetcher
+  )
+  return { pnl: data, error, isLoading }
 }
 
 export function useTradeHistory(profileId: number | null) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   SharedPortfolioView,
   TradeOrder,
   TradeOrderRequest,
+  PnlResponse,
 } from "./types";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -169,3 +170,7 @@ export const delegateTrade = (token: string, payload: TradeOrderRequest) =>
     method: "POST",
     body: JSON.stringify(payload),
   });
+
+// Realized P&L
+export const getProfilePnl = (profileId: number) =>
+  request<PnlResponse>(`/api/v1/profiles/${profileId}/pnl`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -137,6 +137,24 @@ export interface PortfolioSnapshot {
   total_usd: number;
 }
 
+// ── Realized P&L ─────────────────────────────────────────────────────────────
+
+export interface PnlAsset {
+  base_asset: string;
+  current_qty: number;
+  avg_cost: number | null;
+  realized_pnl_usd: number;
+  total_bought_usd: number;
+  total_sold_usd: number;
+  buy_count: number;
+  sell_count: number;
+}
+
+export interface PnlResponse {
+  assets: PnlAsset[];
+  total_realized_pnl_usd: number;
+}
+
 export interface SharedPortfolioView {
   token: string;
   profile_name: string;


### PR DESCRIPTION
## Summary
- Adds `PnlAsset` / `PnlResponse` types in `src/lib/types.ts` and `getProfilePnl` API function in `src/lib/api.ts`
- Adds `useProfilePnl(profileId)` SWR hook in `src/hooks/usePortfolio.ts`
- Adds `RealizedPnL` component with total header, per-asset table (qty, avg cost, realized P&L, buy/sell counts), and a disclaimer: *"CoinHQ trades only (excludes positions traded directly on exchanges)"*
- Surfaces the panel on the dashboard above Trade History; shows profile-select hint when in aggregate view

## Test plan
- [ ] `npx tsc --noEmit` — no errors
- [ ] `CI=1 npx vitest run` — 53 tests pass (7 new in `realizedpnl.test.tsx`)
- [ ] `CI=1 npx next build` — clean build, dashboard route 12.2 kB

🤖 Generated with [Claude Code](https://claude.com/claude-code)