### PR TITLE
test: demo mode + seed data + integration/E2E suites; fix 4 verified bugs

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,5 @@
 .vercel
+
+# Redis dump artifact (local dev)
+dump.rdb
+*.rdb

--- a/backend/alembic/versions/011_share_links_timestamptz.py
+++ b/backend/alembic/versions/011_share_links_timestamptz.py
@@ -1,0 +1,42 @@
+"""make share_links timestamp columns timezone-aware
+
+The app writes timezone-aware datetimes (datetime.now(UTC)) to share_links.
+The original columns were created as TIMESTAMP WITHOUT TIME ZONE (migrations
+002/004), which asyncpg rejects for tz-aware values ("can't subtract
+offset-naive and offset-aware datetimes"), breaking the public share view and
+view-count update on Postgres. Convert them to TIMESTAMP WITH TIME ZONE.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-07-16
+"""
+from alembic import op
+
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+_COLS = ("expires_at", "last_viewed_at", "created_at")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return  # SQLite is tz-agnostic; nothing to alter
+    for col in _COLS:
+        op.execute(
+            f"ALTER TABLE share_links ALTER COLUMN {col} "
+            f"TYPE TIMESTAMP WITH TIME ZONE USING {col} AT TIME ZONE 'UTC'"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for col in _COLS:
+        op.execute(
+            f"ALTER TABLE share_links ALTER COLUMN {col} "
+            f"TYPE TIMESTAMP WITHOUT TIME ZONE USING {col} AT TIME ZONE 'UTC'"
+        )

--- a/backend/app/api/v1/keys.py
+++ b/backend/app/api/v1/keys.py
@@ -8,7 +8,7 @@ from app.core.database import get_db
 from app.core.limits import check_exchange_limit
 from app.core.logging import logger
 from app.core.security import encrypt, get_current_user
-from app.exchanges.factory import SUPPORTED_EXCHANGES, get_adapter
+from app.exchanges.factory import get_adapter, supported_exchanges
 from app.models.exchange_key import ExchangeKey
 from app.models.profile import Profile
 from app.models.user import User
@@ -73,10 +73,11 @@ async def add_key(
             detail="tier_limit: You have reached the exchange limit for your current plan. Upgrade to Premium for unlimited exchanges.",
         )
 
-    if new_exchange not in SUPPORTED_EXCHANGES:
+    allowed = supported_exchanges()
+    if new_exchange not in allowed:
         raise HTTPException(
             status_code=400,
-            detail=f"Unsupported exchange. Supported: {SUPPORTED_EXCHANGES}",
+            detail=f"Unsupported exchange. Supported: {allowed}",
         )
 
     # Validate key works before storing. A read-only key must reject ALL write

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,6 +7,9 @@ class Settings(BaseSettings):
     # App
     APP_NAME: str = "CoinHQ"
     DEBUG: bool = False
+    # Demo mode: enables the "demo" paper exchange (deterministic fake balances,
+    # simulated order fills). Never enable in production.
+    DEMO_MODE: bool = False
 
     # Database
     DATABASE_URL: str = "postgresql+asyncpg://coinhq:coinhq@localhost:5432/coinhq"

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -16,9 +16,10 @@ def _engine_kwargs() -> dict:
         kwargs["connect_args"] = {"ssl": "require", "statement_cache_size": 0}
     # Serverless (Vercel sets VERCEL=1): don't keep a connection pool per function
     # instance — let the external pooler manage connections. Elsewhere use a real pool.
+    # SQLite (dev/demo/tests) accepts neither pool_size nor max_overflow.
     if os.getenv("VERCEL"):
         kwargs["poolclass"] = NullPool
-    else:
+    elif settings.DATABASE_URL.startswith("postgresql"):
         kwargs["pool_size"] = 10
         kwargs["max_overflow"] = 20
     return kwargs

--- a/backend/app/exchanges/demo.py
+++ b/backend/app/exchanges/demo.py
@@ -1,0 +1,94 @@
+"""Demo (paper) exchange adapter — deterministic fake data for local/dev use.
+
+Only registered in the factory when settings.DEMO_MODE is true. No network
+calls are ever made. Behavior is driven by markers in the api_key so tests
+and demos can exercise both happy paths and rejection paths:
+
+- api_key containing "write"    → validate_key() rejects (write permissions)
+- api_key containing "withdraw" → validate_trade_key() rejects (withdrawal perms)
+- api_key containing "alt"      → smaller "altcoin" balance preset
+- api_key containing "empty"    → no balances
+- otherwise                     → main balance preset
+
+place_order() simulates an immediate MARKET fill and returns a Binance-like
+response, sizing executedQty from the supplied price (or canned demo prices).
+"""
+
+import uuid
+
+from app.exchanges.base import ExchangeAdapter
+from app.schemas.portfolio import Balance
+
+# Canned prices used only to size simulated fills when no live price is passed.
+DEMO_PRICES: dict[str, float] = {
+    "BTC": 65_000.0,
+    "ETH": 3_400.0,
+    "SOL": 150.0,
+    "ADA": 0.45,
+    "DOGE": 0.12,
+    "USDT": 1.0,
+    "USDC": 1.0,
+}
+
+_PRESET_MAIN = [
+    ("BTC", 0.4200, 0.0100),
+    ("ETH", 3.2500, 0.0000),
+    ("SOL", 25.000, 5.0000),
+    ("USDT", 1500.0, 0.0000),
+    ("ADA", 800.00, 0.0000),
+]
+
+_PRESET_ALT = [
+    ("ETH", 0.8000, 0.0000),
+    ("DOGE", 5000.0, 0.0000),
+    ("USDT", 250.00, 0.0000),
+]
+
+
+class DemoAdapter(ExchangeAdapter):
+    """Paper exchange: deterministic balances, always-valid keys, simulated fills."""
+
+    def _preset(self) -> list[tuple[str, float, float]]:
+        key = self.api_key.lower()
+        if "empty" in key:
+            return []
+        if "alt" in key:
+            return _PRESET_ALT
+        return _PRESET_MAIN
+
+    async def get_balances(self) -> list[Balance]:
+        return [
+            Balance(asset=asset, free=free, locked=locked, total=free + locked)
+            for asset, free, locked in self._preset()
+        ]
+
+    async def validate_key(self) -> bool:
+        if "write" in self.api_key.lower():
+            raise ValueError("Write permissions detected. Only read-only API keys are accepted.")
+        return True
+
+    async def validate_trade_key(self) -> bool:
+        if "withdraw" in self.api_key.lower():
+            raise ValueError(
+                "This key can withdraw or transfer funds. Trade keys must have "
+                "withdrawals and transfers disabled."
+            )
+        return True
+
+    async def place_order(
+        self, base_asset: str, side: str, quote_quantity_usd: float, price: float | None = None
+    ) -> dict:
+        side_u = side.upper()
+        if side_u not in ("BUY", "SELL"):
+            raise ValueError("side must be 'buy' or 'sell'")
+        asset = base_asset.upper()
+        px = price or DEMO_PRICES.get(asset)
+        executed_qty = round(quote_quantity_usd / px, 8) if px and px > 0 else None
+        return {
+            "orderId": f"demo-{uuid.uuid4().hex[:12]}",
+            "symbol": f"{asset}USDT",
+            "side": side_u,
+            "status": "FILLED",
+            "executedQty": str(executed_qty) if executed_qty is not None else None,
+            "cummulativeQuoteQty": str(round(quote_quantity_usd, 2)),
+        }

--- a/backend/app/exchanges/demo.py
+++ b/backend/app/exchanges/demo.py
@@ -19,7 +19,9 @@ import uuid
 from app.exchanges.base import ExchangeAdapter
 from app.schemas.portfolio import Balance
 
-# Canned prices used only to size simulated fills when no live price is passed.
+# Deterministic demo prices. Used both to size simulated fills and (in DEMO_MODE)
+# by the price service, so demos/E2E always see the same portfolio total.
+# MAIN preset total = .43*65000 + 3.25*3400 + 30*150 + 1500*1 + 800*.45 = 45360.
 DEMO_PRICES: dict[str, float] = {
     "BTC": 65_000.0,
     "ETH": 3_400.0,

--- a/backend/app/exchanges/factory.py
+++ b/backend/app/exchanges/factory.py
@@ -1,5 +1,6 @@
 import httpx
 
+from app.core.config import settings
 from app.exchanges.base import ExchangeAdapter
 
 
@@ -11,6 +12,9 @@ def get_adapter(
 ) -> ExchangeAdapter:
     """Return the appropriate exchange adapter."""
     exchange = exchange.lower()
+    if exchange == "demo" and settings.DEMO_MODE:
+        from app.exchanges.demo import DemoAdapter
+        return DemoAdapter(api_key, api_secret, http_client=http_client)
     if exchange == "binance":
         from app.exchanges.binance import BinanceAdapter
         return BinanceAdapter(api_key, api_secret, http_client=http_client)
@@ -37,3 +41,10 @@ def get_adapter(
 
 
 SUPPORTED_EXCHANGES = ["binance", "bybit", "okx", "coinbase", "kraken", "binancetr", "gateio"]
+
+
+def supported_exchanges() -> list[str]:
+    """Exchanges accepted by the API right now ("demo" only in DEMO_MODE)."""
+    if settings.DEMO_MODE:
+        return [*SUPPORTED_EXCHANGES, "demo"]
+    return list(SUPPORTED_EXCHANGES)

--- a/backend/app/models/share_link.py
+++ b/backend/app/models/share_link.py
@@ -1,7 +1,7 @@
 import secrets
 from datetime import datetime
 
-from sqlalchemy import Boolean, ForeignKey, String, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -20,11 +20,13 @@ class ShareLink(Base):
     show_exchange_names: Mapped[bool] = mapped_column(Boolean, default=False)
     show_allocation_pct: Mapped[bool] = mapped_column(Boolean, default=True)
 
-    expires_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    # Timezone-aware: the app writes datetime.now(UTC); a naive column makes
+    # asyncpg reject those tz-aware values on Postgres.
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     view_count: Mapped[int] = mapped_column(default=0)
-    last_viewed_at: Mapped[datetime | None] = mapped_column(nullable=True)
-    created_at: Mapped[datetime] = mapped_column(default=func.now())
+    last_viewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=func.now())
     label: Mapped[str | None] = mapped_column(String(100), nullable=True)
     allow_follow: Mapped[bool] = mapped_column(Boolean, default=True)
 

--- a/backend/app/services/portfolio_service.py
+++ b/backend/app/services/portfolio_service.py
@@ -118,9 +118,19 @@ async def get_portfolio(
             data["cached"] = True
             return PortfolioResponse(**data)
 
+    # One balance fetch per exchange. A profile may hold BOTH a read_only and a
+    # trade key for the same exchange (same underlying account) — fetching each
+    # would double-count the portfolio. Prefer the read_only key for reads.
+    keys_by_exchange: dict[str, ExchangeKey] = {}
+    for key in keys:
+        existing = keys_by_exchange.get(key.exchange)
+        if existing is None or (existing.key_type != "read_only" and key.key_type == "read_only"):
+            keys_by_exchange[key.exchange] = key
+    dedup_keys = list(keys_by_exchange.values())
+
     # Fetch all exchange balances in parallel
     raw_results = await asyncio.gather(
-        *[_fetch_exchange_balance(key, http_client=http_client) for key in keys],
+        *[_fetch_exchange_balance(key, http_client=http_client) for key in dedup_keys],
         return_exceptions=True,
     )
 

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -262,6 +262,12 @@ async def get_usd_prices(
     if not assets:
         return {}
 
+    # Demo mode is fully offline & deterministic: no live Binance/CoinGecko calls,
+    # so demos and E2E always see the same portfolio total.
+    if settings.DEMO_MODE:
+        from app.exchanges.demo import DEMO_PRICES
+        return {a: DEMO_PRICES[a] for a in assets if a in DEMO_PRICES}
+
     close_client = http_client is None
     client = http_client or httpx.AsyncClient(timeout=10)
 

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -19,8 +19,43 @@ _BINANCE_PRICE_CACHE_KEY = "binance:all_prices"
 _BINANCE_PRICE_TTL = 30  # seconds
 
 # Redis key for CoinGecko symbol→id map (large and stable, cache 24h)
-_CG_COIN_LIST_CACHE_KEY = "coingecko:coin_list"
+# v2: bump after adding curated id overrides so poisoned cached maps expire.
+_CG_COIN_LIST_CACHE_KEY = "coingecko:coin_list:v2"
 _CG_COIN_LIST_TTL = 86_400  # 24 hours
+
+# /coins/list is ordered alphabetically by id, NOT by market cap, so "first
+# match wins" can resolve a major symbol to a dust token (e.g. BTC → some
+# scam coin at $0.000005). Pin the majors to their canonical CoinGecko ids.
+_CG_ID_OVERRIDES: dict[str, str] = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+    "SOL": "solana",
+    "BNB": "binancecoin",
+    "XRP": "ripple",
+    "ADA": "cardano",
+    "DOGE": "dogecoin",
+    "TRX": "tron",
+    "DOT": "polkadot",
+    "LINK": "chainlink",
+    "LTC": "litecoin",
+    "AVAX": "avalanche-2",
+    "MATIC": "matic-network",
+    "POL": "polygon-ecosystem-token",
+    "SHIB": "shiba-inu",
+    "UNI": "uniswap",
+    "ATOM": "cosmos",
+    "XLM": "stellar",
+    "ETC": "ethereum-classic",
+    "NEAR": "near",
+    "APT": "aptos",
+    "ARB": "arbitrum",
+    "OP": "optimism",
+    "TON": "the-open-network",
+    "PEPE": "pepe",
+}
+
+# Stablecoins are $1 regardless of price source.
+_STABLECOINS = {"USDT": 1.0, "USDC": 1.0, "BUSD": 1.0, "FDUSD": 1.0, "TUSD": 1.0, "DAI": 1.0}
 
 # Redis key prefix for CoinGecko per-coin USD prices
 _CG_PRICE_CACHE_PREFIX = "coingecko:price:"
@@ -111,6 +146,10 @@ async def _get_coingecko_symbol_map(
         elif cg_id == sym.lower():
             # Exact lowercase-symbol == id is the canonical/well-known coin
             symbol_map[sym] = cg_id
+
+    # Curated overrides always win — the list is alphabetical, not market-cap,
+    # so majors would otherwise resolve to dust tokens with the same symbol.
+    symbol_map.update(_CG_ID_OVERRIDES)
 
     if symbol_map and redis_client is not None:
         try:
@@ -254,6 +293,12 @@ async def get_usd_prices(
         result: dict[str, float] = {
             asset: all_prices[asset] for asset in assets if asset in all_prices
         }
+
+        # Stablecoins are $1 regardless of source (also covers the case where
+        # Binance is unreachable/geo-blocked and everything falls to CoinGecko).
+        for asset in assets:
+            if asset in _STABLECOINS:
+                result[asset] = _STABLECOINS[asset]
 
         # CoinGecko fallback for assets that Binance didn't price
         unpriced = [a for a in assets if a not in result]

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -1,0 +1,181 @@
+"""Seed deterministic demo data for local development, E2E tests and UI demos.
+
+Usage (from backend/):
+    DEMO_MODE=true DATABASE_URL=sqlite+aiosqlite:////tmp/coinhq-demo.db \
+    JWT_SECRET=... ENCRYPTION_KEY=... uv run python scripts/seed_demo.py
+
+Creates (idempotent — wipes and re-creates all tables first):
+  Users:    demo@coinhq.dev (free), pro@coinhq.dev (premium), admin@coinhq.dev (admin)
+  Profiles: demo→"Main Portfolio" (demo read_only+trade keys)
+            pro →"Trading" (demo keys), "HODL" (demo-alt read_only)
+  Share links on demo/Main:
+    open+trade   — all show_* true, can_trade with BTC,ETH whitelist,
+                   $500/order, $2000/24h, direction both
+    masked       — hide amounts+exchange names, no trade, no follow
+    sell-only    — can_trade, direction sell, no other limits
+    expired      — expires in the past (must 410)
+    revoked      — is_active false (must 404)
+  Trade history on demo/Main (filled buys+sells → non-trivial P&L)
+  Portfolio snapshots (14 days, both demo profiles)
+  Waitlist entries
+
+Prints a JSON blob with user JWTs and share tokens for E2E consumption.
+"""
+
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker  # noqa: E402
+
+from app.core.database import Base, engine  # noqa: E402
+from app.core.security import create_access_token, encrypt  # noqa: E402
+from app.models import (  # noqa: E402
+    ExchangeKey,
+    PortfolioSnapshot,
+    Profile,
+    ShareLink,
+    TradeOrder,
+    User,
+    Waitlist,
+)
+
+Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+NOW = datetime.now(UTC)
+
+
+def _key(profile_id: int, marker: str, key_type: str) -> ExchangeKey:
+    return ExchangeKey(
+        profile_id=profile_id,
+        exchange="demo",
+        key_type=key_type,
+        encrypted_key=encrypt(f"demo-{marker}-{key_type}-key-12345678"),
+        encrypted_secret=encrypt(f"demo-{marker}-secret-12345678"),
+    )
+
+
+async def seed() -> dict:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with Session() as db:
+        demo = User(email="demo@coinhq.dev", name="Demo User", google_id="demo-google-1", tier="free")
+        pro = User(email="pro@coinhq.dev", name="Pro User", google_id="demo-google-2", tier="premium")
+        admin = User(email="admin@coinhq.dev", name="Admin", google_id="demo-google-3", tier="admin")
+        db.add_all([demo, pro, admin])
+        await db.flush()
+
+        p_main = Profile(user_id=demo.id, name="Main Portfolio")
+        p_trading = Profile(user_id=pro.id, name="Trading")
+        p_hodl = Profile(user_id=pro.id, name="HODL")
+        db.add_all([p_main, p_trading, p_hodl])
+        await db.flush()
+
+        db.add_all([
+            _key(p_main.id, "main", "read_only"),
+            _key(p_main.id, "main", "trade"),
+            _key(p_trading.id, "main", "read_only"),
+            _key(p_trading.id, "main", "trade"),
+            _key(p_hodl.id, "alt", "read_only"),
+        ])
+
+        links = {
+            "open_trade": ShareLink(
+                profile_id=p_main.id, token=ShareLink.generate_token(),
+                show_total_value=True, show_coin_amounts=True,
+                show_exchange_names=True, show_allocation_pct=True,
+                label="Danisman (trade)", allow_follow=True,
+                can_trade=True, trade_direction="both",
+                trade_allowed_coins="BTC,ETH",
+                trade_max_per_order_usd=500.0, trade_daily_limit_usd=2000.0,
+            ),
+            "masked": ShareLink(
+                profile_id=p_main.id, token=ShareLink.generate_token(),
+                show_total_value=True, show_coin_amounts=False,
+                show_exchange_names=False, show_allocation_pct=True,
+                label="Muhasebeci", allow_follow=False, can_trade=False,
+            ),
+            "sell_only": ShareLink(
+                profile_id=p_main.id, token=ShareLink.generate_token(),
+                show_total_value=True, show_coin_amounts=True,
+                show_exchange_names=True, show_allocation_pct=True,
+                label="Sadece satis", allow_follow=True,
+                can_trade=True, trade_direction="sell",
+            ),
+            "expired": ShareLink(
+                profile_id=p_main.id, token=ShareLink.generate_token(),
+                expires_at=NOW - timedelta(days=1), label="Suresi dolmus",
+            ),
+            "revoked": ShareLink(
+                profile_id=p_main.id, token=ShareLink.generate_token(),
+                is_active=False, label="Iptal edilmis",
+            ),
+        }
+        db.add_all(links.values())
+        await db.flush()
+
+        # Trade history → AVCO P&L: buy 0.01 BTC @60k, buy 0.01 @70k (avg 65k),
+        # sell 0.01 @68k → realized +30. Plus an ETH buy and a delegate trade.
+        trades = [
+            TradeOrder(profile_id=p_main.id, exchange="demo", symbol="BTCUSDT", base_asset="BTC",
+                       side="buy", usd_value=600.0, amount=0.01, actor="owner", status="filled",
+                       exchange_order_id="demo-hist-1"),
+            TradeOrder(profile_id=p_main.id, exchange="demo", symbol="BTCUSDT", base_asset="BTC",
+                       side="buy", usd_value=700.0, amount=0.01, actor="owner", status="filled",
+                       exchange_order_id="demo-hist-2"),
+            TradeOrder(profile_id=p_main.id, exchange="demo", symbol="BTCUSDT", base_asset="BTC",
+                       side="sell", usd_value=680.0, amount=0.01, actor="owner", status="filled",
+                       exchange_order_id="demo-hist-3"),
+            TradeOrder(profile_id=p_main.id, exchange="demo", symbol="ETHUSDT", base_asset="ETH",
+                       side="buy", usd_value=340.0, amount=0.1, actor="owner", status="filled",
+                       exchange_order_id="demo-hist-4"),
+            TradeOrder(profile_id=p_main.id, share_link_id=links["open_trade"].id,
+                       exchange="demo", symbol="ETHUSDT", base_asset="ETH",
+                       side="buy", usd_value=150.0, amount=0.044, actor="delegate", status="filled",
+                       exchange_order_id="demo-hist-5"),
+            TradeOrder(profile_id=p_main.id, exchange="demo", symbol="SOLUSDT", base_asset="SOL",
+                       side="buy", usd_value=100.0, amount=None, actor="owner", status="failed",
+                       error="Demo: insufficient balance"),
+        ]
+        # Spread created_at over the past days for a realistic history view
+        for i, t in enumerate(trades):
+            t.created_at = NOW - timedelta(days=len(trades) - i, hours=3)
+        db.add_all(trades)
+
+        # 14 days of snapshots per profile (gentle upward drift)
+        for profile, base in ((p_main, 30_000.0), (p_trading, 12_000.0), (p_hodl, 3_000.0)):
+            for d in range(14, 0, -1):
+                drift = 1 + (14 - d) * 0.01 + (0.015 if d % 3 == 0 else -0.008)
+                db.add(PortfolioSnapshot(
+                    profile_id=profile.id,
+                    total_usd=round(base * drift, 2),
+                    created_at=NOW - timedelta(days=d),
+                ))
+
+        db.add_all([
+            Waitlist(email="wait1@example.com", plan="premium", source="web"),
+            Waitlist(email="wait2@example.com", plan="premium", source="web"),
+        ])
+
+        await db.commit()
+
+        return {
+            "users": {
+                "demo": {"id": demo.id, "email": demo.email, "jwt": create_access_token(demo.id)},
+                "pro": {"id": pro.id, "email": pro.email, "jwt": create_access_token(pro.id)},
+                "admin": {"id": admin.id, "email": admin.email, "jwt": create_access_token(admin.id)},
+            },
+            "profiles": {"main": p_main.id, "trading": p_trading.id, "hodl": p_hodl.id},
+            "share_tokens": {name: link.token for name, link in links.items()},
+        }
+
+
+if __name__ == "__main__":
+    info = asyncio.run(seed())
+    print(json.dumps(info, indent=2))

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker  # noqa: E402
 
+from app.core.config import settings  # noqa: E402
 from app.core.database import Base, engine  # noqa: E402
 from app.core.security import create_access_token, encrypt  # noqa: E402
 from app.models import (  # noqa: E402
@@ -59,7 +60,27 @@ def _key(profile_id: int, marker: str, key_type: str) -> ExchangeKey:
     )
 
 
+def _assert_safe_target() -> None:
+    """Refuse to run the destructive reset against anything but a demo/test DB.
+
+    This script drops and recreates ALL tables, so guard against ever pointing it
+    at a real database (e.g. a shell that already exports a production
+    DATABASE_URL). Require DEMO_MODE AND a sqlite/clearly-demo URL.
+    """
+    url = settings.DATABASE_URL
+    is_sqlite = url.startswith("sqlite")
+    looks_demo = any(marker in url for marker in ("demo", "test", ":memory:"))
+    if not settings.DEMO_MODE:
+        raise SystemExit("Refusing to seed: DEMO_MODE is not enabled.")
+    if not (is_sqlite or looks_demo):
+        raise SystemExit(
+            f"Refusing to run the destructive demo seed against {url!r}: "
+            "use a sqlite/demo DATABASE_URL (name must contain 'demo' or 'test')."
+        )
+
+
 async def seed() -> dict:
+    _assert_safe_target()
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)

--- a/backend/tests/test_integration_conditions.py
+++ b/backend/tests/test_integration_conditions.py
@@ -1,0 +1,1008 @@
+"""HTTP-level integration tests for the CoinHQ backend.
+
+Runs the REAL FastAPI app (`app.main.app`) over httpx.AsyncClient +
+ASGITransport. The lifespan does NOT run, so `app.state.redis` (stateful
+stub) and `app.state.http_client` are installed by a session fixture.
+The global async engine (app.core.database) is used against a SQLite file
+DB; every test drops + recreates all tables for a clean slate.
+
+Price determinism: `get_usd_prices` is monkeypatched in both
+app.services.portfolio_service and app.services.trade_service to a fixed
+price table — no network traffic ever happens (the "demo" adapter makes no
+HTTP calls either).
+
+Condition groups below; individual tests reference the C-xxx condition IDs
+from docs/SYSTEM_TEST_PLAN.md in their docstrings:
+  IC-1  auth & multi-user isolation        IC-8  delegated trade via share token
+  IC-2  tier limits (profiles/exchanges)   IC-9  owner trade
+  IC-3  exchange key validation/storage    IC-10 realized PnL (AVCO)
+  IC-4  portfolio pricing & aggregation    IC-11 portfolio history
+  IC-5  share-link permission matrix       IC-12 waitlist
+  IC-6  share-link lifecycle               IC-13 admin stats
+  IC-7  follow/unfollow                    IC-14 rate limiter registration
+
+Run with:
+  DATABASE_URL='sqlite+aiosqlite:////tmp/coinhq-inttest.db' JWT_SECRET=x \
+  ENCRYPTION_KEY=<Fernet key> uv run --all-extras pytest tests/test_integration_conditions.py -q
+"""
+
+import os
+
+from cryptography.fernet import Fernet
+
+# Must happen before any app import — settings are read at import time.
+_TEST_FERNET_KEY = Fernet.generate_key().decode()
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:////tmp/coinhq-inttest.db")
+os.environ.setdefault("ENCRYPTION_KEY", _TEST_FERNET_KEY)
+os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret")
+
+import re
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from app.api.v1 import portfolio as portfolio_api
+from app.api.v1 import share as share_api
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal, Base, engine
+from app.core.security import create_access_token, encrypt, reset_fernet_cache
+from app.main import app
+from app.models.exchange_key import ExchangeKey
+from app.models.portfolio_snapshot import PortfolioSnapshot
+from app.models.trade_order import TradeOrder
+from app.models.user import User
+
+API = "/api/v1"
+
+# Fixed price table (never hit the network)
+PRICES = {"BTC": 65000.0, "ETH": 3400.0, "SOL": 150.0, "USDT": 1.0, "ADA": 0.45, "DOGE": 0.12}
+
+# DEMO adapter MAIN preset totals (free+locked) priced with PRICES
+MAIN_USD = {
+    "BTC": 0.43 * 65000.0,   # 27950.0
+    "ETH": 3.25 * 3400.0,    # 11050.0
+    "SOL": 30.0 * 150.0,     # 4500.0
+    "USDT": 1500.0 * 1.0,    # 1500.0
+    "ADA": 800.0 * 0.45,     # 360.0
+}
+MAIN_TOTAL = sum(MAIN_USD.values())  # 45360.0
+
+# DEMO adapter ALT preset ("alt" marker in api_key)
+ALT_USD = {"ETH": 0.8 * 3400.0, "DOGE": 5000.0 * 0.12, "USDT": 250.0}
+ALT_TOTAL = sum(ALT_USD.values())  # 3570.0
+
+READ_KEY = "demo-readonly-key-0001"
+TRADE_KEY = "demo-trading-key-0001"
+ALT_KEY = "demo-altcoins-key-0001"
+SECRET = "demo-secret-000000001"
+
+
+async def _fixed_prices(assets, http_client=None, redis_client=None):
+    return {a: PRICES[a] for a in assets if a in PRICES}
+
+
+class _RedisStub:
+    """Minimal stateful async-Redis stand-in (get/set/setex/delete/ping)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value
+        return True
+
+    async def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+    async def ping(self):
+        return True
+
+
+@pytest.fixture(scope="session")
+def app_state():
+    """Lifespan replacement: install redis stub + http client on app.state."""
+    app.state.redis = _RedisStub()
+    app.state.http_client = httpx.AsyncClient(timeout=5.0)
+    return app.state
+
+
+@pytest.fixture
+async def client(app_state, monkeypatch):
+    # Deterministic crypto + demo exchange, restored on teardown.
+    old_demo, old_enc = settings.DEMO_MODE, settings.ENCRYPTION_KEY
+    settings.DEMO_MODE = True
+    settings.ENCRYPTION_KEY = _TEST_FERNET_KEY
+    reset_fernet_cache()
+
+    # Fresh cache + rate-limit counters per test.
+    app_state.redis.store.clear()
+    for lim in (app.state.limiter, share_api.limiter, portfolio_api.limiter):
+        try:
+            lim.reset()
+        except Exception:  # noqa: BLE001 — storage without reset support
+            pass
+
+    # Fixed prices — no network.
+    monkeypatch.setattr("app.services.portfolio_service.get_usd_prices", _fixed_prices)
+    monkeypatch.setattr("app.services.trade_service.get_usd_prices", _fixed_prices)
+
+    # Clean schema per test on the global engine.
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    await engine.dispose()
+    settings.DEMO_MODE = old_demo
+    settings.ENCRYPTION_KEY = old_enc
+    reset_fernet_cache()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+async def _seed_user(email: str, tier: str = "free") -> User:
+    async with AsyncSessionLocal() as s:
+        user = User(email=email, google_id=f"gid-{email}", name=email.split("@")[0], tier=tier)
+        s.add(user)
+        await s.commit()
+        await s.refresh(user)
+        return user
+
+
+def _auth(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(user.id)}"}
+
+
+async def _insert(*objs):
+    async with AsyncSessionLocal() as s:
+        s.add_all(objs)
+        await s.commit()
+        for o in objs:
+            await s.refresh(o)
+    return objs
+
+
+async def _mk_profile(client, headers, name: str = "Main") -> dict:
+    r = await client.post(f"{API}/profiles/", json={"name": name}, headers=headers)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+async def _post_demo_key(client, headers, profile_id, key_type="read_only", api_key=None):
+    return await client.post(
+        f"{API}/profiles/{profile_id}/keys/",
+        json={
+            "exchange": "demo",
+            "api_key": api_key or (TRADE_KEY if key_type == "trade" else READ_KEY),
+            "api_secret": SECRET,
+            "key_type": key_type,
+        },
+        headers=headers,
+    )
+
+
+async def _owner_with_key(client, *, tier="free", key_type="read_only",
+                          email="owner@example.com", profile_name="Main", api_key=None):
+    """User + profile + validated demo key, all through the HTTP API."""
+    user = await _seed_user(email, tier)
+    headers = _auth(user)
+    profile = await _mk_profile(client, headers, profile_name)
+    if key_type is not None:
+        r = await _post_demo_key(client, headers, profile["id"], key_type=key_type, api_key=api_key)
+        assert r.status_code == 201, r.text
+    return user, headers, profile
+
+
+async def _mk_share(client, headers, profile_id, **overrides) -> dict:
+    r = await client.post(f"{API}/share", json={"profile_id": profile_id, **overrides}, headers=headers)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _naive_utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+# ═════════════════════════════════ IC-1 AUTH / ISOLATION ═════════════════════
+
+async def test_request_without_token_is_rejected(client):
+    """C-013/C-014: no Authorization header → 401/403; garbage token → 401."""
+    r = await client.get(f"{API}/profiles/")
+    assert r.status_code in (401, 403), r.text
+
+    r = await client.get(f"{API}/profiles/", headers={"Authorization": "Bearer not-a-jwt"})
+    assert r.status_code == 401, r.text
+
+
+async def test_cannot_read_foreign_profile(client):
+    """C-024: GET another user's profile → 403 (or 404); own profile → 200."""
+    alice, alice_h, profile = await _owner_with_key(client, email="alice@example.com", key_type=None)
+    bob = await _seed_user("bob@example.com")
+
+    r = await client.get(f"{API}/profiles/{profile['id']}", headers=_auth(bob))
+    assert r.status_code in (403, 404), r.text
+
+    r = await client.get(f"{API}/profiles/{profile['id']}", headers=alice_h)
+    assert r.status_code == 200
+
+
+async def test_cannot_delete_foreign_profile(client):
+    """C-026: DELETE another user's profile → 403/404, profile survives."""
+    alice, alice_h, profile = await _owner_with_key(client, email="alice@example.com", key_type=None)
+    bob = await _seed_user("bob@example.com")
+
+    r = await client.delete(f"{API}/profiles/{profile['id']}", headers=_auth(bob))
+    assert r.status_code in (403, 404), r.text
+
+    r = await client.get(f"{API}/profiles/{profile['id']}", headers=alice_h)
+    assert r.status_code == 200, "profile must still exist after foreign delete attempt"
+
+
+async def test_cannot_add_key_to_foreign_profile(client):
+    """C-029: POST a key onto another user's profile → 403/404 and nothing stored."""
+    alice, alice_h, profile = await _owner_with_key(client, email="alice@example.com", key_type=None)
+    bob = await _seed_user("bob@example.com")
+
+    r = await _post_demo_key(client, _auth(bob), profile["id"])
+    assert r.status_code in (403, 404), r.text
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/keys/", headers=alice_h)
+    assert r.status_code == 200
+    assert r.json() == [], "no key may be created on a foreign profile"
+
+
+# ═════════════════════════════════ IC-2 TIER LIMITS ══════════════════════════
+
+async def test_free_tier_second_profile_rejected(client):
+    """C-018/C-153: free tier is limited to 1 profile — second create → 403."""
+    user = await _seed_user("free@example.com", tier="free")
+    headers = _auth(user)
+    await _mk_profile(client, headers, "First")
+
+    r = await client.post(f"{API}/profiles/", json={"name": "Second"}, headers=headers)
+    assert r.status_code == 403, r.text
+    assert "limit" in r.json()["detail"].lower()
+
+
+async def test_premium_tier_multiple_profiles_ok(client):
+    """C-019/C-155: premium tier may create several profiles."""
+    user = await _seed_user("prem@example.com", tier="premium")
+    headers = _auth(user)
+    for name in ("P1", "P2", "P3"):
+        await _mk_profile(client, headers, name)
+
+    r = await client.get(f"{API}/profiles/", headers=headers)
+    assert r.status_code == 200
+    assert len(r.json()) == 3
+
+
+async def test_free_tier_third_distinct_exchange_rejected(client):
+    """C-031/C-154: free tier allows 2 distinct exchanges per profile — 3rd → 403 tier_limit."""
+    user, headers, profile = await _owner_with_key(client, email="free@example.com")
+    # Second distinct exchange seeded directly (only 'demo' validates offline).
+    await _insert(ExchangeKey(
+        profile_id=profile["id"], exchange="binance", key_type="read_only",
+        encrypted_key=encrypt("k" * 16), encrypted_secret=encrypt("s" * 16),
+    ))
+
+    r = await client.post(
+        f"{API}/profiles/{profile['id']}/keys/",
+        json={"exchange": "bybit", "api_key": "x" * 16, "api_secret": "y" * 16},
+        headers=headers,
+    )
+    assert r.status_code == 403, r.text
+    assert "tier_limit" in r.json()["detail"]
+
+
+async def test_second_key_type_for_same_exchange_does_not_count_against_limit(client):
+    """C-032/C-154: read_only + trade key for the SAME exchange = one exchange slot."""
+    user, headers, profile = await _owner_with_key(client, email="free@example.com")
+    # Fill the free-tier limit of 2 distinct exchanges.
+    await _insert(ExchangeKey(
+        profile_id=profile["id"], exchange="binance", key_type="read_only",
+        encrypted_key=encrypt("k" * 16), encrypted_secret=encrypt("s" * 16),
+    ))
+
+    # Adding a TRADE key for the already-present 'demo' exchange must succeed.
+    r = await _post_demo_key(client, headers, profile["id"], key_type="trade")
+    assert r.status_code == 201, r.text
+    assert r.json()["key_type"] == "trade"
+
+
+# ═════════════════════════════════ IC-3 KEY VALIDATION ═══════════════════════
+
+async def test_unsupported_exchange_rejected(client):
+    """C-030: unknown exchange name → 400."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    r = await client.post(
+        f"{API}/profiles/{profile['id']}/keys/",
+        json={"exchange": "hogwarts", "api_key": "x" * 16, "api_secret": "y" * 16},
+        headers=headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "Unsupported exchange" in r.json()["detail"]
+
+
+async def test_read_only_key_with_write_permission_rejected(client):
+    """C-034: read-only key that has write permissions ('write' marker) → 400."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    r = await _post_demo_key(client, headers, profile["id"], api_key="demo-write-key-000001")
+    assert r.status_code == 400, r.text
+    assert "Write permissions" in r.json()["detail"]
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/keys/", headers=headers)
+    assert r.json() == [], "rejected key must not be stored"
+
+
+async def test_trade_key_with_withdraw_permission_rejected(client):
+    """C-036: trade key that can withdraw ('withdraw' marker) → 400."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    r = await _post_demo_key(
+        client, headers, profile["id"], key_type="trade", api_key="demo-withdraw-key-0001"
+    )
+    assert r.status_code == 400, r.text
+    assert "withdraw" in r.json()["detail"].lower()
+
+
+async def test_read_only_key_created_and_secrets_never_returned(client):
+    """C-035/C-028: valid demo key → 201 key_type=read_only; api_key/secret never in response."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    r = await _post_demo_key(client, headers, profile["id"])
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["key_type"] == "read_only"
+    assert body["exchange"] == "demo"
+    assert "api_key" not in body and "api_secret" not in body
+    assert "encrypted_key" not in body and "encrypted_secret" not in body
+    assert READ_KEY not in r.text and SECRET not in r.text
+
+    # List response is equally clean.
+    r = await client.get(f"{API}/profiles/{profile['id']}/keys/", headers=headers)
+    assert READ_KEY not in r.text and SECRET not in r.text
+
+
+async def test_trade_key_created(client):
+    """C-038: valid demo trade key → 201 key_type=trade."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    r = await _post_demo_key(client, headers, profile["id"], key_type="trade")
+    assert r.status_code == 201, r.text
+    assert r.json()["key_type"] == "trade"
+    assert TRADE_KEY not in r.text and SECRET not in r.text
+
+
+# ═════════════════════════════════ IC-4 PORTFOLIO ════════════════════════════
+
+async def test_profile_portfolio_values_with_fixed_prices(client):
+    """C-052 (pricing): demo MAIN preset priced with the fixed table — exact usd_value/total."""
+    user, headers, profile = await _owner_with_key(client)
+
+    r = await client.get(f"{API}/portfolio/profile/{profile['id']}", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert len(body["exchanges"]) == 1
+    ex = body["exchanges"][0]
+    assert ex["exchange"] == "demo"
+
+    by_asset = {b["asset"]: b for b in ex["balances"]}
+    assert set(by_asset) == set(MAIN_USD)
+    for asset, usd in MAIN_USD.items():
+        assert by_asset[asset]["usd_value"] == pytest.approx(usd), asset
+    assert by_asset["BTC"]["total"] == pytest.approx(0.43)
+
+    assert ex["total_usd"] == pytest.approx(MAIN_TOTAL)
+    assert body["total_usd"] == pytest.approx(MAIN_TOTAL)  # 45360.0
+
+
+async def test_aggregate_portfolio_sums_all_profiles(client):
+    """C-056: /portfolio/aggregate — grand_total = sum of both profiles."""
+    user = await _seed_user("prem@example.com", tier="premium")
+    headers = _auth(user)
+    p1 = await _mk_profile(client, headers, "Alpha")
+    p2 = await _mk_profile(client, headers, "Beta")
+    assert (await _post_demo_key(client, headers, p1["id"])).status_code == 201
+    assert (await _post_demo_key(client, headers, p2["id"], api_key=ALT_KEY)).status_code == 201
+
+    r = await client.get(f"{API}/portfolio/aggregate", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert len(body["profiles"]) == 2
+    totals = {p["profile_name"]: p["total_usd"] for p in body["profiles"]}
+    assert totals["Alpha"] == pytest.approx(MAIN_TOTAL)
+    assert totals["Beta"] == pytest.approx(ALT_TOTAL)
+    assert body["grand_total_usd"] == pytest.approx(MAIN_TOTAL + ALT_TOTAL)  # 48930.0
+    assert body["asset_totals"]["ETH"] == pytest.approx(MAIN_USD["ETH"] + ALT_USD["ETH"])
+    assert body["asset_totals"]["DOGE"] == pytest.approx(ALT_USD["DOGE"])
+
+
+# ═════════════════════════════ IC-5 SHARE PERMISSION MATRIX ══════════════════
+
+_ALL_ON = dict(show_total_value=True, show_coin_amounts=True,
+               show_exchange_names=True, show_allocation_pct=True)
+
+
+async def _shared_view(client, headers, profile_id, **flags):
+    link = await _mk_share(client, headers, profile_id, **flags)
+    r = await client.get(f"{API}/public/share/{link['token']}")
+    assert r.status_code == 200, r.text
+    return link, r.json()
+
+
+async def test_share_view_all_flags_on(client):
+    """C-080 (TTTT)/C-078: all flags on → totals, amounts, real exchange name, allocation visible."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(client, headers, profile["id"], **_ALL_ON)
+
+    assert view["total_usd"] == pytest.approx(MAIN_TOTAL)
+    ex = view["exchanges"][0]
+    assert ex["exchange_name"] == "demo"
+    assert ex["total_usd"] == pytest.approx(MAIN_TOTAL)
+    by_asset = {a["asset"]: a for a in ex["assets"]}
+    assert by_asset["BTC"]["amount"] == pytest.approx(0.43)
+    assert by_asset["BTC"]["usd_value"] == pytest.approx(MAIN_USD["BTC"])
+    assert by_asset["BTC"]["allocation_pct"] == pytest.approx(
+        round(MAIN_USD["BTC"] / MAIN_TOTAL * 100, 2)
+    )
+    assert sum(a["allocation_pct"] for a in ex["assets"]) == pytest.approx(100, abs=0.1)
+
+
+async def test_share_view_all_flags_off(client):
+    """C-080 (FFFF)/C-075/C-076/C-077: all flags off → every sensitive field is null / masked."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(
+        client, headers, profile["id"],
+        show_total_value=False, show_coin_amounts=False,
+        show_exchange_names=False, show_allocation_pct=False,
+    )
+
+    assert view["total_usd"] is None
+    for ex in view["exchanges"]:
+        assert ex["total_usd"] is None
+        assert re.fullmatch(r"Exchange [0-9a-f]{8}", ex["exchange_name"]), ex["exchange_name"]
+        assert "demo" not in ex["exchange_name"]
+        for a in ex["assets"]:
+            assert a["amount"] is None
+            assert a["usd_value"] is None
+            assert a["allocation_pct"] is None
+
+
+async def test_share_view_total_hidden_only(client):
+    """C-075: show_total_value=False → total_usd, asset.usd_value AND exchange.total_usd null."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(client, headers, profile["id"],
+                                 **{**_ALL_ON, "show_total_value": False})
+
+    assert view["total_usd"] is None
+    for ex in view["exchanges"]:
+        assert ex["total_usd"] is None
+        for a in ex["assets"]:
+            assert a["usd_value"] is None
+            assert a["amount"] is not None  # amounts stay visible
+
+
+async def test_share_view_amounts_hidden_only(client):
+    """C-076: show_coin_amounts=False → amount null, USD values stay visible."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(client, headers, profile["id"],
+                                 **{**_ALL_ON, "show_coin_amounts": False})
+
+    assert view["total_usd"] == pytest.approx(MAIN_TOTAL)
+    for a in view["exchanges"][0]["assets"]:
+        assert a["amount"] is None
+        assert a["usd_value"] is not None
+
+
+async def test_share_view_exchange_names_masked_only(client):
+    """C-077: show_exchange_names=False → 'Exchange <hash>' mask, real name never appears."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(client, headers, profile["id"],
+                                 **{**_ALL_ON, "show_exchange_names": False})
+
+    ex = view["exchanges"][0]
+    assert re.fullmatch(r"Exchange [0-9a-f]{8}", ex["exchange_name"]), ex["exchange_name"]
+    assert "demo" not in ex["exchange_name"].lower()
+    assert ex["total_usd"] == pytest.approx(MAIN_TOTAL)  # other fields unaffected
+
+
+async def test_share_view_allocation_hidden_only(client):
+    """C-078: show_allocation_pct=False → allocation_pct null, rest visible."""
+    user, headers, profile = await _owner_with_key(client)
+    _, view = await _shared_view(client, headers, profile["id"],
+                                 **{**_ALL_ON, "show_allocation_pct": False})
+
+    for a in view["exchanges"][0]["assets"]:
+        assert a["allocation_pct"] is None
+        assert a["usd_value"] is not None
+
+
+async def test_share_view_profile_name_never_leaks(client):
+    """C-082: real profile name is never exposed — label or 'Crypto Portfolio'."""
+    secret_name = "SecretProfileName77"
+    user, headers, profile = await _owner_with_key(client, profile_name=secret_name)
+
+    _, view = await _shared_view(client, headers, profile["id"])
+    assert view["profile_name"] == "Crypto Portfolio"
+    assert secret_name not in str(view)
+
+    _, view2 = await _shared_view(client, headers, profile["id"], label="Public Label")
+    assert view2["profile_name"] == "Public Label"
+    assert secret_name not in str(view2)
+
+
+# ═════════════════════════════ IC-6 SHARE LIFECYCLE ══════════════════════════
+
+async def test_expired_share_link_returns_410(client):
+    """C-073: expired link → 410 Gone."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"],
+                           expires_at="2020-01-01T00:00:00Z")
+    r = await client.get(f"{API}/public/share/{link['token']}")
+    assert r.status_code == 410, r.text
+
+
+async def test_revoked_share_link_returns_404(client):
+    """C-069/C-072: owner revokes → public view 404."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"])
+
+    r = await client.delete(f"{API}/share/{link['id']}", headers=headers)
+    assert r.status_code == 204, r.text
+
+    r = await client.get(f"{API}/public/share/{link['token']}")
+    assert r.status_code == 404, r.text
+
+
+async def test_cannot_revoke_foreign_share_link(client):
+    """C-070: revoking someone else's link → 404 and the link keeps working."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"])
+    mallory = await _seed_user("mallory@example.com")
+
+    r = await client.delete(f"{API}/share/{link['id']}", headers=_auth(mallory))
+    assert r.status_code == 404, r.text
+
+    r = await client.get(f"{API}/public/share/{link['token']}")
+    assert r.status_code == 200, "foreign revoke attempt must not deactivate the link"
+
+
+async def test_patch_share_link_applies_immediately_to_public_view(client):
+    """C-063/C-066: PATCH can_trade on/off + limit updates apply to the very next public request."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True,
+                           trade_max_per_order_usd=100.0)
+
+    r = await client.get(f"{API}/public/share/{link['token']}")
+    assert r.json()["can_trade"] is True
+    assert r.json()["trade_max_per_order_usd"] == pytest.approx(100.0)
+
+    r = await client.patch(
+        f"{API}/share/{link['id']}",
+        json={"trade_max_per_order_usd": 55.0, "trade_direction": "buy"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    view = (await client.get(f"{API}/public/share/{link['token']}")).json()
+    assert view["trade_max_per_order_usd"] == pytest.approx(55.0)
+    assert view["trade_direction"] == "buy"
+
+    # Toggle trading off → next delegate trade is refused immediately.
+    r = await client.patch(f"{API}/share/{link['id']}", json={"can_trade": False}, headers=headers)
+    assert r.status_code == 200
+
+    view = (await client.get(f"{API}/public/share/{link['token']}")).json()
+    assert view["can_trade"] is False
+
+    r = await client.post(
+        f"{API}/public/share/{link['token']}/trade",
+        json={"exchange": "demo", "asset": "BTC", "side": "buy", "usd_amount": 10},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_share_link_view_count_increments(client):
+    """C-074: every public view bumps view_count."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"])
+
+    for _ in range(2):
+        assert (await client.get(f"{API}/public/share/{link['token']}")).status_code == 200
+
+    r = await client.get(f"{API}/share", params={"profile_id": profile["id"]}, headers=headers)
+    assert r.status_code == 200
+    row = next(x for x in r.json() if x["id"] == link["id"])
+    assert row["view_count"] == 2
+
+
+# ═════════════════════════════════ IC-7 FOLLOW ═══════════════════════════════
+
+async def test_follow_disallowed_when_allow_follow_false(client):
+    """C-090: allow_follow=False → follow attempt → 403."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"], allow_follow=False)
+    bob = await _seed_user("bob@example.com")
+
+    r = await client.post(f"{API}/followed/{link['token']}", headers=_auth(bob))
+    assert r.status_code == 403, r.text
+
+
+async def test_follow_then_refollow_is_idempotent(client):
+    """C-088/C-092: first follow → 201; second follow returns the SAME record (200/201)."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"], allow_follow=True)
+    bob = await _seed_user("bob@example.com")
+    bob_h = _auth(bob)
+
+    r1 = await client.post(f"{API}/followed/{link['token']}", headers=bob_h)
+    assert r1.status_code == 201, r1.text
+
+    r2 = await client.post(f"{API}/followed/{link['token']}", headers=bob_h)
+    assert r2.status_code in (200, 201), r2.text
+    assert r2.json()["id"] == r1.json()["id"], "refollow must not create a second record"
+
+    r = await client.get(f"{API}/followed", headers=bob_h)
+    assert len(r.json()) == 1
+
+
+async def test_cannot_unfollow_foreign_follow_record(client):
+    """C-094: DELETE another user's followed record → 404; own unfollow → 204."""
+    user, headers, profile = await _owner_with_key(client)
+    link = await _mk_share(client, headers, profile["id"])
+    bob = await _seed_user("bob@example.com")
+    carol = await _seed_user("carol@example.com")
+    bob_h = _auth(bob)
+
+    followed = (await client.post(f"{API}/followed/{link['token']}", headers=bob_h)).json()
+
+    r = await client.delete(f"{API}/followed/{followed['id']}", headers=_auth(carol))
+    assert r.status_code == 404, r.text
+
+    r = await client.delete(f"{API}/followed/{followed['id']}", headers=bob_h)
+    assert r.status_code == 204, r.text
+    assert (await client.get(f"{API}/followed", headers=bob_h)).json() == []
+
+
+# ═══════════════════════════ IC-8 DELEGATED TRADE ════════════════════════════
+
+def _trade_body(usd, side="buy", asset="BTC", exchange="demo"):
+    return {"exchange": exchange, "asset": asset, "side": side, "usd_amount": usd}
+
+
+async def test_delegate_trade_refused_when_can_trade_false(client):
+    """C-098: link with can_trade=False → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=False)
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade", json=_trade_body(10))
+    assert r.status_code == 403, r.text
+
+
+async def test_delegate_trade_direction_enforced(client):
+    """C-105: sell-only link rejects a buy order → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True,
+                           trade_direction="sell")
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade",
+                          json=_trade_body(10, side="buy"))
+    assert r.status_code == 403, r.text
+    assert "sell" in r.json()["detail"].lower()
+
+
+async def test_delegate_trade_coin_whitelist_enforced(client):
+    """C-107: coin outside the whitelist → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True,
+                           trade_allowed_coins="BTC,ETH")
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade",
+                          json=_trade_body(10, asset="SOL"))
+    assert r.status_code == 403, r.text
+    assert "SOL" in r.json()["detail"]
+
+
+async def test_delegate_trade_per_order_limit_enforced(client):
+    """C-110: order above trade_max_per_order_usd → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True,
+                           trade_max_per_order_usd=50.0)
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade", json=_trade_body(60))
+    assert r.status_code == 403, r.text
+    assert "per-order" in r.json()["detail"]
+
+
+async def test_delegate_trade_daily_limit_is_cumulative(client):
+    """C-111/C-112: 24h limit $100 — 40 + 60 fill it exactly, the 3rd order (any size) → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True,
+                           trade_daily_limit_usd=100.0)
+    url = f"{API}/public/share/{link['token']}/trade"
+
+    r1 = await client.post(url, json=_trade_body(40))
+    assert r1.status_code == 200, r1.text
+    r2 = await client.post(url, json=_trade_body(60))
+    assert r2.status_code == 200, r2.text
+
+    r3 = await client.post(url, json=_trade_body(10))
+    assert r3.status_code == 403, r3.text
+    assert "24h limit" in r3.json()["detail"]
+
+    # Public view reports the accumulated spend.
+    view = (await client.get(f"{API}/public/share/{link['token']}")).json()
+    assert view["trade_spent_today_usd"] == pytest.approx(100.0)
+
+
+async def test_delegate_trade_success_is_filled_and_recorded(client):
+    """C-114: valid delegate order → 200 filled; TradeOrder row carries share_link_id."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True)
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade", json=_trade_body(650))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "filled"
+    assert body["actor"] == "delegate"
+    assert body["symbol"] == "BTCUSDT"
+    assert body["exchange_order_id"], "demo adapter returns an order id"
+    assert body["amount"] == pytest.approx(650 / 65000.0)  # 0.01 BTC at the fixed price
+
+    async with AsyncSessionLocal() as s:
+        row = (await s.execute(select(TradeOrder))).scalars().one()
+    assert row.share_link_id == link["id"]
+    assert row.actor == "delegate"
+    assert row.status == "filled"
+    assert row.usd_value == pytest.approx(650.0)
+
+
+async def test_can_trade_link_requires_profile_trade_key(client):
+    """C-061/C-065: profile without a trade key cannot get a can_trade link (create or PATCH) → 400."""
+    user, headers, profile = await _owner_with_key(client)  # read_only key only
+
+    r = await client.post(f"{API}/share",
+                          json={"profile_id": profile["id"], "can_trade": True},
+                          headers=headers)
+    assert r.status_code == 400, r.text
+
+    link = await _mk_share(client, headers, profile["id"])  # can_trade defaults to False
+    r = await client.patch(f"{API}/share/{link['id']}", json={"can_trade": True}, headers=headers)
+    assert r.status_code == 400, r.text
+
+
+async def test_delegate_trade_non_positive_amount_rejected(client):
+    """C-100: usd_amount <= 0 → 422 (schema gt=0) or 400."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True)
+    url = f"{API}/public/share/{link['token']}/trade"
+
+    for bad in (0, -5):
+        r = await client.post(url, json=_trade_body(bad))
+        assert r.status_code in (400, 422), r.text
+
+
+async def test_delegate_trade_invalid_side_rejected(client):
+    """C-099: side outside buy|sell → 422."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True)
+
+    r = await client.post(f"{API}/public/share/{link['token']}/trade",
+                          json=_trade_body(10, side="hodl"))
+    assert r.status_code == 422, r.text
+
+
+# ═════════════════════════════════ IC-9 OWNER TRADE ══════════════════════════
+
+async def test_owner_trade_fills_and_ignores_share_limits(client):
+    """C-120/C-121: owner trades are NOT constrained by share-link limits."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    # A share link with tiny limits exists — must not affect the owner.
+    await _mk_share(client, headers, profile["id"], can_trade=True,
+                    trade_max_per_order_usd=1.0, trade_daily_limit_usd=1.0)
+
+    r = await client.post(f"{API}/profiles/{profile['id']}/trade",
+                          json=_trade_body(50_000), headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "filled"
+    assert body["actor"] == "owner"
+    assert body["amount"] == pytest.approx(50_000 / 65000.0)
+
+    async with AsyncSessionLocal() as s:
+        row = (await s.execute(select(TradeOrder))).scalars().one()
+    assert row.share_link_id is None, "owner trades carry no share_link_id"
+
+
+async def test_owner_trade_on_foreign_profile_404(client):
+    """C-118: trading on someone else's profile → 404."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    mallory = await _seed_user("mallory@example.com")
+
+    r = await client.post(f"{API}/profiles/{profile['id']}/trade",
+                          json=_trade_body(10), headers=_auth(mallory))
+    assert r.status_code == 404, r.text
+
+
+async def test_owner_trade_without_trade_key_400(client):
+    """C-119/C-103: profile has only a read-only key → 400 'No trade key'."""
+    user, headers, profile = await _owner_with_key(client)  # read_only
+
+    r = await client.post(f"{API}/profiles/{profile['id']}/trade",
+                          json=_trade_body(10), headers=headers)
+    assert r.status_code == 400, r.text
+    assert "No trade key" in r.json()["detail"]
+
+
+async def test_trade_history_lists_owner_and_delegate_orders(client):
+    """C-125/C-126/C-128: GET /profiles/{id}/trade returns the orders we placed."""
+    user, headers, profile = await _owner_with_key(client, key_type="trade")
+    link = await _mk_share(client, headers, profile["id"], can_trade=True)
+
+    r = await client.post(f"{API}/profiles/{profile['id']}/trade",
+                          json=_trade_body(130, asset="BTC"), headers=headers)
+    assert r.status_code == 200, r.text
+    r = await client.post(f"{API}/public/share/{link['token']}/trade",
+                          json=_trade_body(34, asset="ETH"))
+    assert r.status_code == 200, r.text
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/trade", headers=headers)
+    assert r.status_code == 200
+    orders = r.json()
+    assert len(orders) == 2
+    actors = {o["actor"] for o in orders}
+    assert actors == {"owner", "delegate"}
+    assets = {o["base_asset"] for o in orders}
+    assert assets == {"BTC", "ETH"}
+
+
+# ═════════════════════════════════ IC-10 PNL ═════════════════════════════════
+
+async def test_pnl_avco_realized_profit(client):
+    """C-132/C-136: buy $600 (0.01) + buy $700 (0.01) + sell $680 (0.01) → realized +$30 (AVCO)."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    t0 = _naive_utcnow() - timedelta(hours=1)
+
+    def order(side, usd, minutes):
+        return TradeOrder(
+            profile_id=profile["id"], exchange="demo", symbol="BTCUSDT", base_asset="BTC",
+            side=side, usd_value=usd, amount=0.01, actor="owner", status="filled",
+            created_at=t0 + timedelta(minutes=minutes),
+        )
+
+    await _insert(order("buy", 600.0, 0), order("buy", 700.0, 1), order("sell", 680.0, 2))
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/pnl", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["assets"]) == 1
+    btc = body["assets"][0]
+    assert btc["base_asset"] == "BTC"
+    # AVCO: avg cost = (600+700)/0.02 = 65000/unit; sell at 68000/unit → +30 on 0.01
+    assert btc["realized_pnl_usd"] == pytest.approx(30.0)
+    assert btc["current_qty"] == pytest.approx(0.01)
+    assert btc["avg_cost"] == pytest.approx(65000.0)
+    assert btc["buy_count"] == 2 and btc["sell_count"] == 1
+    assert body["total_realized_pnl_usd"] == pytest.approx(30.0)
+
+
+async def test_pnl_foreign_profile_forbidden(client):
+    """C-129: PnL of another user's profile → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    mallory = await _seed_user("mallory@example.com")
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/pnl", headers=_auth(mallory))
+    assert r.status_code == 403, r.text
+
+
+# ═════════════════════════════════ IC-11 HISTORY ═════════════════════════════
+
+async def test_history_returns_snapshots_and_days_filter_works(client):
+    """C-140/C-141: default window (30d) hides old snapshots; days=365 includes them."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    now = _naive_utcnow()
+    await _insert(
+        PortfolioSnapshot(profile_id=profile["id"], total_usd=111.0,
+                          created_at=now - timedelta(days=40)),
+        PortfolioSnapshot(profile_id=profile["id"], total_usd=222.0,
+                          created_at=now - timedelta(hours=1)),
+    )
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/history/", headers=headers)
+    assert r.status_code == 200, r.text
+    points = r.json()
+    assert [p["total_usd"] for p in points] == [222.0]
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/history/",
+                         params={"days": 365}, headers=headers)
+    points = r.json()
+    assert [p["total_usd"] for p in points] == [111.0, 222.0]  # oldest → newest
+
+
+async def test_history_foreign_profile_forbidden(client):
+    """C-138: history of another user's profile → 403."""
+    user, headers, profile = await _owner_with_key(client, key_type=None)
+    mallory = await _seed_user("mallory@example.com")
+
+    r = await client.get(f"{API}/profiles/{profile['id']}/history/", headers=_auth(mallory))
+    assert r.status_code == 403, r.text
+
+
+# ═════════════════════════════════ IC-12 WAITLIST ════════════════════════════
+
+async def test_waitlist_signup_is_idempotent(client):
+    """C-144/C-145/C-146/C-147: first POST → 201; duplicate email → 200 with SAME record."""
+    r1 = await client.post(f"{API}/waitlist", json={"email": "Neo@Example.com", "plan": "premium"})
+    assert r1.status_code == 201, r1.text
+    assert r1.json()["email"] == "neo@example.com"  # normalized
+
+    r2 = await client.post(f"{API}/waitlist", json={"email": "neo@example.com"})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["id"] == r1.json()["id"]
+
+    r3 = await client.post(f"{API}/waitlist", json={"email": "not-an-email"})
+    assert r3.status_code == 422, r3.text
+
+
+# ═════════════════════════════════ IC-13 ADMIN ═══════════════════════════════
+
+async def test_admin_stats_forbidden_for_non_admin(client):
+    """C-149: free/premium users get 403 from /admin/stats."""
+    user = await _seed_user("pleb@example.com", tier="premium")
+    r = await client.get(f"{API}/admin/stats", headers=_auth(user))
+    assert r.status_code == 403, r.text
+
+
+async def test_admin_stats_counts_are_consistent(client):
+    """C-151/C-152: admin sees consistent counts (revoked share links excluded)."""
+    owner, headers, profile = await _owner_with_key(client, email="owner@example.com")
+    active = await _mk_share(client, headers, profile["id"])
+    revoked = await _mk_share(client, headers, profile["id"])
+    assert (await client.delete(f"{API}/share/{revoked['id']}", headers=headers)).status_code == 204
+    admin = await _seed_user("root@example.com", tier="admin")
+
+    r = await client.get(f"{API}/admin/stats", headers=_auth(admin))
+    assert r.status_code == 200, r.text
+    stats = r.json()
+    assert stats["users"] == 2
+    assert stats["profiles"] == 1
+    assert stats["exchange_keys"] == 1
+    assert stats["active_share_links"] == 1, f"revoked link must not be counted (link {active['id']} active)"
+    assert stats["exchanges"] == {"demo": 1}
+    assert stats["tiers"] == {"free": 1, "admin": 1}
+
+
+# ═════════════════════════════ IC-14 RATE LIMITING ═══════════════════════════
+
+async def test_rate_limits_are_registered_on_endpoints(client):
+    """C-048/C-083/C-117 (presence only): slowapi limiter installed; endpoints carry limits.
+
+    (The 30/min & 10/min ceilings are not exhausted here on purpose — presence of the
+    registered limits + app.state.limiter is asserted instead.)
+    """
+    assert getattr(app.state, "limiter", None) is not None
+
+    share_limits = share_api.limiter._route_limits
+    assert any("public_share_view" in name for name in share_limits), share_limits.keys()
+    assert any("delegate_trade" in name for name in share_limits), share_limits.keys()
+
+    portfolio_limits = portfolio_api.limiter._route_limits
+    assert any("portfolio_for_profile" in name for name in portfolio_limits)
+    assert any("aggregate_portfolio" in name for name in portfolio_limits)
+
+    # The public share view is declared at 30/minute; portfolio at settings value (10/minute).
+    view_key = next(n for n in share_limits if "public_share_view" in n)
+    assert "30 per 1 minute" in [str(lim.limit) for lim in share_limits[view_key]]
+    prof_key = next(n for n in portfolio_limits if "portfolio_for_profile" in n)
+    assert "10 per 1 minute" in [str(lim.limit) for lim in portfolio_limits[prof_key]]

--- a/backend/tests/test_price_service.py
+++ b/backend/tests/test_price_service.py
@@ -353,19 +353,20 @@ class TestCoinGeckoFallback:
     async def test_symbol_id_disambiguation_exact_match_preferred(self):
         """
         When multiple coins share a ticker, the one whose id == lowercased symbol
-        is preferred over the first match.
+        is preferred over the first match. Uses a ticker NOT in _CG_ID_OVERRIDES
+        so the disambiguation heuristic (not the curated override) is exercised.
         """
         binance_resp = _make_binance_resp([])
 
-        # 'xrp' appears first as 'xrp-legacy' then the canonical 'xrp'
+        # 'zzz' appears first as 'zzz-legacy' then the canonical 'zzz'
         coin_list_resp = _make_cg_coins_resp(
             [
-                {"id": "xrp-legacy", "symbol": "XRP", "name": "XRP Legacy"},
-                {"id": "xrp", "symbol": "XRP", "name": "XRP"},
+                {"id": "zzz-legacy", "symbol": "ZZZ", "name": "ZZZ Legacy"},
+                {"id": "zzz", "symbol": "ZZZ", "name": "ZZZ"},
             ]
         )
-        # Only the canonical id 'xrp' will be queried
-        cg_price_resp = _make_cg_price_resp({"xrp": {"usd": 0.5}})
+        # Only the canonical id 'zzz' will be queried
+        cg_price_resp = _make_cg_price_resp({"zzz": {"usd": 0.5}})
 
         async def mock_get(url, **kwargs):
             if "binance.com" in url:
@@ -375,8 +376,8 @@ class TestCoinGeckoFallback:
             if "simple/price" in url:
                 # Verify the canonical id was sent
                 params = kwargs.get("params", {})
-                assert "xrp" in params.get("ids", ""), (
-                    f"Expected canonical id 'xrp' in ids, got: {params}"
+                assert "zzz" in params.get("ids", ""), (
+                    f"Expected canonical id 'zzz' in ids, got: {params}"
                 )
                 return cg_price_resp
             raise AssertionError(f"Unexpected URL: {url}")
@@ -390,7 +391,48 @@ class TestCoinGeckoFallback:
         mock_redis.setex = AsyncMock()
 
         result = await get_usd_prices(
-            ["XRP"], http_client=mock_client, redis_client=mock_redis
+            ["ZZZ"], http_client=mock_client, redis_client=mock_redis
         )
 
-        assert result["XRP"] == pytest.approx(0.5)
+        assert result["ZZZ"] == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_curated_override_wins_over_first_match(self):
+        """
+        Majors are pinned via _CG_ID_OVERRIDES because /coins/list is alphabetical,
+        not market-cap ordered. BTC must resolve to 'bitcoin' even when a same-symbol
+        dust token appears first in the list.
+        """
+        binance_resp = _make_binance_resp([])
+        coin_list_resp = _make_cg_coins_resp(
+            [
+                {"id": "aaa-btc-scam", "symbol": "BTC", "name": "Fake BTC"},
+                {"id": "bitcoin", "symbol": "BTC", "name": "Bitcoin"},
+            ]
+        )
+        cg_price_resp = _make_cg_price_resp({"bitcoin": {"usd": 65000.0}})
+
+        async def mock_get(url, **kwargs):
+            if "binance.com" in url:
+                return binance_resp
+            if "coins/list" in url:
+                return coin_list_resp
+            if "simple/price" in url:
+                params = kwargs.get("params", {})
+                assert params.get("ids", "") == "bitcoin", (
+                    f"Override must pin BTC→bitcoin, got: {params}"
+                )
+                return cg_price_resp
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.aclose = AsyncMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        result = await get_usd_prices(
+            ["BTC"], http_client=mock_client, redis_client=mock_redis
+        )
+        assert result["BTC"] == pytest.approx(65000.0)

--- a/docs/SYSTEM_TEST_PLAN.md
+++ b/docs/SYSTEM_TEST_PLAN.md
@@ -1,0 +1,457 @@
+# CoinHQ — Sistem Test Planı (Uçtan Uca Davranış + Koşul Matrisi)
+
+Bu doküman, sistemin uçtan uca **nasıl çalışması gerektiğini** ve test edilecek
+**koşul matrisini** tanımlar. Kaynak: `docs/FEATURES.md`, `README.md`,
+`backend/app/api/v1/*.py`, `backend/app/core/{limits.py,trade_limits.py,security.py}`,
+`backend/app/services/*.py`, `backend/app/models/*.py`, `frontend/src/app/**/page.tsx`
+ve `frontend/src/components/`.
+
+**Okuma kılavuzu:** Her koşul `C-XXX` ile numaralandırılmıştır ve tek satırlık,
+test-edilebilir bir kuraldır: *verilen durum → beklenen sonuç (HTTP kodu / davranış)*.
+`EDGE` etiketli koşullar mevcut kod davranışını pinler; ürün kararı gerektirebilir.
+
+---
+
+## 1. Sistem Akışları (Kısa)
+
+### 1.1 Auth — Google OAuth → JWT → Refresh
+1. `GET /api/v1/auth/google` → Redis'e tek kullanımlık CSRF `state` yazılır (TTL 10 dk) → Google consent'e redirect.
+2. `GET /api/v1/auth/google/callback` → `state` Redis'ten atomik silinerek doğrulanır (yoksa 403) → code→token exchange → userinfo → `google_id` üzerinden user **upsert** (email/name güncellenir) → access token (24 saat, `type=access`) + refresh token (7 gün, `type=refresh`) üretilir → `{FRONTEND_URL}/auth/callback?token=...&refresh_token=...` redirect.
+3. Frontend token'ları `localStorage`'a yazar; her istekte `Authorization: Bearer`. 401 alınca **bir kez** `POST /auth/refresh` denenir; başarısızsa token'lar silinip `/login`'e yönlendirilir.
+4. Korumalı her endpoint `get_current_user` dependency'sinden geçer (JWT decode + DB'den user).
+
+### 1.2 Profil / Key Yönetimi
+- Profiller kullanıcıya aittir; tüm CRUD `profile.user_id == current_user.id` ile izole edilir.
+- Key ekleme: `key_type` `read_only` veya `trade`. Kaydetmeden **önce** adapter ile canlı validasyon:
+  - `read_only` → `validate_key()`: herhangi bir write/trade izni varsa `ValueError` → **400 (KEY REDDEDİLİR)**.
+  - `trade` → `validate_trade_key()`: spot trade yapabilmeli; **withdrawal/transfer izni varsa reddedilir** (400).
+- Key + secret Fernet (AES-256) ile şifrelenip saklanır; response şeması (`ExchangeKeyRead`) yalnız `id, profile_id, exchange, key_type, created_at` içerir.
+- Aynı profil + exchange için bir `read_only` VE bir `trade` key olabilir (DB unique: `profile_id+exchange+key_type`). Tier limiti **distinct exchange** sayısına bakar; aynı borsanın ikinci tip key'i limite sayılmaz.
+
+### 1.3 Portföy — Exchange Fetch → Fiyatlama → Cache → Snapshot
+1. `GET /portfolio/profile/{id}` (rate limit `10/minute`/IP): Redis `portfolio:profile:{id}` cache'i kontrol edilir (TTL 60 sn, hit'te `cached=true`).
+2. Cache miss'te tüm exchange bakiyeleri paralel çekilir (`asyncio.gather`); hata veren borsa **atlanır** (partial 200).
+3. Fiyatlama: Binance public ticker (tüm USDT çiftleri, Redis 30 sn) → bulunamayan asset'ler için CoinGecko fallback (60 sn/coin) → stablecoin'ler $1 → hiçbirinde yoksa $0.
+4. Cache miss'te profil başına **saatte en fazla 1** `PortfolioSnapshot` yazılır (best-effort).
+5. `GET /portfolio/aggregate`: kullanıcının tüm profilleri paralel; `grand_total_usd` + `asset_totals`; snapshot yazmaz.
+
+### 1.4 Share Link — İzin Bayrakları + Maskeleme + Expiry + Follow
+- Owner kendi profili için link üretir: token `secrets.token_urlsafe(32)` (256-bit). Bayraklar: `show_total_value` (default T), `show_coin_amounts` (F), `show_exchange_names` (F), `show_allocation_pct` (T), `allow_follow` (T) + expiry, label, trade alanları.
+- `GET /public/share/{token}` (auth yok, 30/dk/IP): revoked/yok → 404; expired → **410** (view_count artmadan); başarıda `view_count+1` atomik, `last_viewed_at` güncellenir. Bayraklara göre alanlar `null`'lanır; borsa adları `sha256[:8]` ile deterministik maskelenir; gerçek profil adı hiç dönmez (label yoksa "Crypto Portfolio"); sıfır bakiyeler elenir.
+- Revoke (`DELETE /share/{id}`) `is_active=false` yapar → link anında ölür (404). `PATCH` değişiklikleri public view'a anında yansır.
+- Follow: giriş yapmış kullanıcı `POST /followed/{token}` ile takip eder; `allow_follow=false` → 403; idempotent (unique `user_id+token`).
+
+### 1.5 Delegated Trading (Share Token ile) — ÇEKİM ASLA YOK
+1. `POST /public/share/{token}/trade` (auth yok, 10/dk/IP): token aktif mi (404), expired mı (410), `can_trade` mı (403).
+2. `execute_trade`: profilin ilgili borsadaki **trade** key'i çözülür (yoksa 400) → `check_delegate_trade` sırayla: `can_trade` → yön (`trade_direction`: both|buy|sell) → coin whitelist (CSV, boş=hepsi) → tutar>0 → emir başı USD limiti → 24 saatlik birikimli USD limiti (`spent_today + emir > limit` → red). Her ihlal **403**.
+3. 24s harcama = **aynı linkin** son 24 saatteki `status=filled` order'larının `usd_value` toplamı (owner ve başka linklerin emirleri sayılmaz).
+4. Uygunsa spot MARKET emri backend proxy'den imzalı gider (trade key delegate'e asla gösterilmez); `TradeOrder` kaydı: `actor=delegate`, `share_link_id`, `symbol={ASSET}USDT`, `status=filled`, `amount=executedQty`.
+5. Withdrawal/transfer **hiçbir kod yolunda yoktur**: adapter'larda withdrawal endpoint'i yok + trade key validasyonu withdrawal iznini reddeder.
+
+### 1.6 Owner Trading
+- `POST /profiles/{id}/trade`: sadece profil sahibi (aksi 404). Delegate limitleri **uygulanmaz** (yön/whitelist/limit yok — owner kendi anahtarının sahibidir). Trade key yoksa 400. `actor=owner`, `share_link_id=NULL`.
+
+### 1.7 Trade Audit Log
+- Her emir (owner+delegate, filled/failed) `trade_orders` tablosuna yazılır; `GET /profiles/{id}/trade` son 50 kaydı yeniden-eskiye döner. Bu log aynı zamanda 24s limitinin veri kaynağıdır.
+
+### 1.8 P&L (AVCO)
+- `GET /profiles/{id}/pnl`: yalnız CoinHQ üzerinden geçen `filled` + `amount IS NOT NULL` emirlerle, `created_at` sırasında average-cost yöntemi. Sell'de realized = `satılan_qty × (satış_birim_fiyatı − avg_cost)`; over-sell takip edilen miktara **clamp** edilir. Veriler **kısmidir** (borsada dışarıdan yapılan işlemler görünmez) — UI bunu belirtmelidir.
+
+### 1.9 Portfolio Snapshots / History
+- Snapshot: portföy fetch'inde (cache miss) saatte en fazla 1 kayıt (`total_usd`).
+- `GET /profiles/{id}/history?days=N` (default 30, 1–365): cutoff sonrası snapshot'lar **eski→yeni** döner; dashboard grafiğini besler.
+
+### 1.10 Waitlist
+- `POST /waitlist` (auth yok): email normalize (trim+lowercase) + regex; yeni → 201, duplicate → **200** ile mevcut kayıt (idempotent).
+
+### 1.11 Admin Stats
+- `GET /admin/stats`: yalnız `tier == "admin"` (aksi 403). Döner: `users`, `profiles`, `exchange_keys`, `active_share_links`, borsa dağılımı, tier dağılımı.
+
+### 1.12 Tier Limitleri
+- `free`: **1 profil**, profil başına **2 distinct exchange**. `premium`: sınırsız (-1). Bilinmeyen tier → free'ye düşer. İhlaller **403** (`tier_limit` detayıyla) döner; frontend `UpgradeBanner` gösterir.
+
+---
+
+## 2. KOŞUL MATRİSİ
+
+### A. Auth & Oturum
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-001 | `GET /auth/google` çağrılır | Google consent'e redirect; Redis'e `oauth_state:{state}` yazılır (TTL 600 sn) |
+| C-002 | Callback'e `error` parametresi veya `code`'suz gelinir | 401 "OAuth error" |
+| C-003 | Callback `state` parametresi olmadan çağrılır | 403 "Invalid OAuth state" |
+| C-004 | Callback bilinmeyen/daha önce kullanılmış `state` ile çağrılır | 403 (state tek kullanımlık — Redis delete atomik) |
+| C-005 | Google token exchange non-200 döner | 401 "Failed to exchange OAuth code" |
+| C-006 | Google userinfo non-200 döner | 401 "Failed to fetch user info" |
+| C-007 | Userinfo'da `sub` veya `email` eksik | 400 "Incomplete user info" |
+| C-008 | İlk kez giriş yapan Google hesabı | User kaydı oluşur; `{FRONTEND_URL}/auth/callback?token=...&refresh_token=...` redirect |
+| C-009 | Aynı `google_id` ikinci kez giriş yapar | Duplicate user oluşmaz; email/name güncellenir (upsert) |
+| C-010 | `POST /auth/refresh` geçerli refresh token ile | 200 `{access_token, token_type:"bearer"}` |
+| C-011 | Refresh süresi dolmuş/imzası bozuk token ile | 401 "Invalid or expired refresh token" |
+| C-012 | Refresh endpoint'ine **access** token verilir (`type != refresh`) | 401 |
+| C-013 | Korumalı endpoint `Authorization` header'sız çağrılır | 403 (HTTPBearer "Not authenticated") |
+| C-014 | Korumalı endpoint geçersiz/expired access JWT ile | 401 "Could not validate credentials" |
+| C-015 | JWT geçerli ama user DB'den silinmiş | 401 |
+| C-016 | Access token 24 saat, refresh 7 gün sonra kullanılır | Süre sonunda 401; frontend 401'de bir kez otomatik refresh dener, o da düşerse `/login`'e atar |
+
+### B. Profil Yönetimi (Sahiplik / İzolasyon / Tier)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-017 | `GET /profiles/` | Yalnız kendi profilleri döner (başka kullanıcınınki asla listelenmez), isme göre sıralı |
+| C-018 | Free kullanıcı 1 profili varken 2.'yi oluşturur | 403 "Free tier limit: 1 profile..." |
+| C-019 | Premium kullanıcı çok sayıda profil oluşturur | Her biri 201 (sınırsız) |
+| C-020 | Aynı kullanıcı aynı isimde ikinci profil | 400 "Profile name already exists" |
+| C-021 | Farklı kullanıcı aynı isimde profil | 201 (isim tekilliği kullanıcı-bazlı) |
+| C-022 | Boş / başında-sonunda boşluklu / 100+ karakter isim | 422 (Pydantic pattern + length) |
+| C-023 | `GET /profiles/{id}` var olmayan id | 404 "Profile not found" |
+| C-024 | `GET /profiles/{id}` başka kullanıcının profili | 403 "Access denied" |
+| C-025 | `DELETE /profiles/{id}` kendi profili | 204; keys, share links, trade orders, snapshots **cascade** silinir |
+| C-026 | `DELETE /profiles/{id}` başka kullanıcının profili | 403 |
+| C-027 | `DELETE /profiles/{id}` var olmayan id | 404 |
+
+### C. API Key Yönetimi (Validasyon / Şifreleme)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-028 | `GET /profiles/{id}/keys/` kendi profili | 200; response'ta **api_key/secret alanı yok** (yalnız id, exchange, key_type, created_at) |
+| C-029 | Keys endpoint'leri başka kullanıcının profiliyle | 403; var olmayan profil → 404 |
+| C-030 | Desteklenmeyen exchange (`"kucoin"`) ile key ekleme | 400 "Unsupported exchange" (desteklenen: binance, bybit, okx, coinbase, kraken, binancetr, gateio) |
+| C-031 | Free kullanıcı 2 distinct exchange'i olan profile 3. borsayı ekler | 403, detay `tier_limit:` ile başlar |
+| C-032 | Free kullanıcı mevcut borsaya (ör. binance read_only varken) **aynı borsanın** trade key'ini ekler | 201 — aynı exchange limite ikinci kez sayılmaz |
+| C-033 | Premium kullanıcı 3+ farklı borsa ekler | Hepsi 201 |
+| C-034 | `read_only` key'in exchange'de write/trade izni var | 400 — KEY REDDEDİLİR ("Write permissions detected...") |
+| C-035 | Geçerli salt-okunur key eklenir | 201, `key_type=read_only` |
+| C-036 | `trade` key'in withdrawal/internal-transfer izni var | 400 — REDDEDİLİR ("withdrawals and transfers disabled" mesajı) |
+| C-037 | `trade` key spot trade yapamıyor | 400 "This key cannot trade..." |
+| C-038 | `trade` key spot yapabiliyor, withdrawal kapalı | 201, `key_type=trade` |
+| C-039 | Key/secret yanlış (exchange auth hatası) | 400 "API key validation failed..." |
+| C-040 | Exchange API'ye ulaşılamıyor (timeout/network) | 502 "Could not reach exchange API" — key kaydedilmez |
+| C-041 | Adapter trade validasyonu implemente değil | 400 (NotImplementedError mesajı) |
+| C-042 | `key_type` alanına "read_only"/"trade" dışı değer | 422 (Literal şema) |
+| C-043 | 8 karakterden kısa api_key/api_secret | 422 |
+| C-044 | Aynı profil+exchange+key_type için ikinci key | DB unique constraint reddeder — beklenen anlamlı 400/409 (mevcutta yakalanmayan IntegrityError; test pinlemeli) |
+| C-045 | Başarıyla eklenen key DB'de incelenir | Yalnız Fernet ciphertext var; plaintext key/secret hiçbir kolonda yok |
+| C-046 | `DELETE .../keys/{key_id}` başka profile ait key id ile | 404; kendi key'i → 204 |
+
+### D. Portföy (Fetch / Cache / Fiyatlama / Aggregate)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-047 | `GET /portfolio/profile/{id}` var olmayan → 404; başkasının → | 403 |
+| C-048 | Aynı IP'den dakikada 10'dan fazla portfolio isteği | 429 (slowapi, `RATE_LIMIT_PORTFOLIO=10/minute`) |
+| C-049 | İlk istek (cache miss) → `cached=false`; 60 sn içinde ikinci istek | `cached=true`, exchange'e gidilmez |
+| C-050 | Cache TTL (60 sn) dolduktan sonra istek | Yeniden canlı fetch, `cached=false` |
+| C-051 | Profilin 2 borsasından biri hata veriyor | 200 partial: hatalı borsa yanıttan düşer, diğeri döner (500 fırlatılmaz) |
+| C-052 | Binance USDT çifti olan asset (BTC) + stablecoin (USDT/USDC) | BTC ticker fiyatıyla, stablecoin $1.0 ile fiyatlanır |
+| C-053 | Binance'te çifti olmayan asset | CoinGecko fallback'ten fiyatlanır; orada da yoksa `usd_value=0` (istek patlamaz) |
+| C-054 | Cache miss + son 1 saatte snapshot yok | Yeni `PortfolioSnapshot(total_usd)` yazılır |
+| C-055 | Son 1 saat içinde snapshot varken tekrar fetch | Yeni snapshot yazılmaz (throttle 1/saat) |
+| C-056 | `GET /portfolio/aggregate` | Kullanıcının tüm profilleri; `grand_total_usd` = toplam; `asset_totals` asset bazında birleşik USD |
+| C-057 | Aggregate'te bir profilin fetch'i exception atar | O profil atlanır, kalanlar döner (200) |
+
+### E. Share Link CRUD (Owner Tarafı)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-058 | Kendi profili için `POST /share` | 201; token ~43 karakter URL-safe (256-bit entropi); `share_url=/share/{token}` |
+| C-059 | Başkasının/var olmayan profili için `POST /share` | 404 "Profile not found" (403 değil — kaynak varlığı sızdırılmaz) |
+| C-060 | Bayraklar gönderilmeden link oluşturulur | Default'lar: total=T, amounts=F, exchange_names=F, alloc=T, allow_follow=T, can_trade=F, direction=both, view_count=0 |
+| C-061 | `can_trade=true` ama profilde trade key yok | 400 "Add a trade key ... before enabling trading" |
+| C-062 | `can_trade=true` ve profilde trade key var | 201 |
+| C-063 | `PATCH /share/{id}` kısmi payload | 200; yalnız gönderilen alanlar değişir (PATCH semantiği) |
+| C-064 | `PATCH` başkasının linki / var olmayan link | 404 |
+| C-065 | `PATCH` ile trade key'siz profilde `can_trade=true` yapılır | 400 |
+| C-066 | `PATCH` ile limit düşürülür (ör. daily 2000→100) | Sonraki delegate emri **anında** yeni limite göre değerlendirilir |
+| C-067 | `GET /share` | Yalnız kendi profillerinin **aktif** linkleri (revoked görünmez), yeni→eski |
+| C-068 | `GET /share?profile_id=X` | Yalnız o profilin linkleri |
+| C-069 | `DELETE /share/{id}` kendi linki | 204; `is_active=false` |
+| C-070 | `DELETE /share/{id}` başkasının/var olmayan link | 404 |
+
+### F. Public Share View (Maskeleme / Expiry / View Count)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-071 | `GET /public/share/{token}` bilinmeyen token | 404 "Link not found or has been revoked" |
+| C-072 | Revoke edilmiş linkin token'ı | 404 (revoke anında etkili) |
+| C-073 | `expires_at` geçmiş link | **410** "This link has expired"; `view_count` ARTMAZ |
+| C-074 | Geçerli link görüntülenir (eşzamanlı istekler dahil) | 200; `view_count` atomik +1, `last_viewed_at` güncellenir; owner listede artışı görür |
+| C-075 | `show_total_value=false` | `total_usd`, her asset'in `usd_value`'su ve exchange `total_usd` → `null` |
+| C-076 | `show_coin_amounts=false` | Her asset'in `amount` alanı → `null` |
+| C-077 | `show_exchange_names=false` | Borsa adı → `"Exchange <sha256 ilk 8 hex>"`; deterministik (aynı borsa her görüntülemede aynı maske) ve geri döndürülemez |
+| C-078 | `show_allocation_pct=true` ve toplam > 0 | `allocation_pct = usd/grand_total*100` (2 hane); `false` → `null` |
+| C-079 | `show_allocation_pct=true` + `show_total_value=false` | Yüzdeler görünür ama hiçbir USD değeri görünmez (bayraklar bağımsız) |
+| C-080 | 4 bayrağın 16 kombinasyonu (aşağıdaki tablo) | Her kombinasyonda yalnız ilgili alanlar dolu; diğerleri null/maskeli |
+| C-081 | Bakiyesi 0 olan asset | Public görünümde hiç listelenmez |
+| C-082 | Link label'lı / label'sız | `profile_name` = label ya da "Crypto Portfolio"; **gerçek profil adı ve owner kimliği asla dönmez** |
+| C-083 | Aynı IP'den dakikada 30+ public view isteği | 429 |
+| C-084 | `can_trade=true` link görüntülenir | `tradable_exchanges` trade key'li borsaların **gerçek adları** + `trade_spent_today_usd` döner (delegate nereye emir vereceğini bilmeli) |
+| C-085 | `can_trade=false` link görüntülenir | `tradable_exchanges=[]`, trade limit alanları default |
+| C-086 | Public view auth'suz çağrılır | 200 — login/JWT gerekmez |
+| C-087 | Public view response'u taranır | api_key/secret, user email, user id, profil gerçek adı yok |
+
+**C-080 kombinasyon tablosu** (TV=show_total_value, CA=show_coin_amounts, EN=show_exchange_names, AP=show_allocation_pct):
+
+| TV | CA | EN | AP | USD alanları (total/asset/exchange) | amount | exchange_name | allocation_pct |
+|----|----|----|----|-----------------------------------|--------|---------------|----------------|
+| T | T | T | T | değer | değer | gerçek ad | % |
+| T | T | T | F | değer | değer | gerçek ad | null |
+| T | T | F | T | değer | değer | maskeli | % |
+| T | T | F | F | değer | değer | maskeli | null |
+| T | F | T | T | değer | null | gerçek ad | % |
+| T | F | T | F | değer | null | gerçek ad | null |
+| T | F | F | T | değer | null | maskeli | % |
+| T | F | F | F | değer | null | maskeli | null |
+| F | T | T | T | null | değer | gerçek ad | % |
+| F | T | T | F | null | değer | gerçek ad | null |
+| F | T | F | T | null | değer | maskeli | % |
+| F | T | F | F | null | değer | maskeli | null |
+| F | F | T | T | null | null | gerçek ad | % |
+| F | F | T | F | null | null | gerçek ad | null |
+| F | F | F | T | null | null | maskeli | % |
+| F | F | F | F | null | null | maskeli | null (yalnız asset adları görünür) |
+
+### G. Follow (Takip)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-088 | Giriş yapmış kullanıcı `POST /followed/{token}` (allow_follow=T) | 201 `FollowedPortfolio` kaydı |
+| C-089 | Auth'suz follow denemesi | 403 (bearer yok) |
+| C-090 | `allow_follow=false` linke follow | 403 "This portfolio does not allow following" |
+| C-091 | Revoked/bilinmeyen token'a follow | 404 |
+| C-092 | Aynı kullanıcı aynı token'ı ikinci kez follow eder | İdempotent: 201 ile **aynı** kayıt döner, duplicate oluşmaz (unique `user_id+token`) |
+| C-093 | `GET /followed` | Yalnız kendi takip listesi, yeni→eski |
+| C-094 | `DELETE /followed/{id}` kendi kaydı → 204; başkasının/yok → | 404 |
+| C-095 | EDGE: expired ama `is_active=true` linke follow | Mevcut kod izin verir (expiry follow'da kontrol edilmez) — davranış testle pinlenmeli / ürün kararı |
+
+### H. Delegated Trading (Share Token ile)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-096 | `POST /public/share/{token}/trade` bilinmeyen/revoked token | 404 |
+| C-097 | Expired linkle trade | **410** |
+| C-098 | `can_trade=false` linkle trade | 403 "not permitted to trade" |
+| C-099 | `side` "buy"/"sell" dışı ("hold") | 422 (Pydantic pattern) |
+| C-100 | `usd_amount <= 0` veya sayı değil | 422 (Field gt=0) |
+| C-101 | `exchange`/`asset` eksik ya da boş | 422 |
+| C-102 | Seçilen borsa için profilde **trade** key yok (başka borsada olsa bile) | 400 "No trade key configured for {exchange}..." |
+| C-103 | Profilde yalnız read_only key varken trade | 400 (read_only key ile asla emir verilmez) |
+| C-104 | `trade_direction=buy` iken `side=sell` | 403 "Only buy orders are permitted" |
+| C-105 | `trade_direction=sell` iken `side=buy` | 403 "Only sell orders are permitted" |
+| C-106 | `trade_direction=both` | Her iki yön de yön kontrolünden geçer |
+| C-107 | Whitelist "BTC,ETH" iken `asset=SOL` | 403 "SOL is not in the allowed coin list" |
+| C-108 | Whitelist " btc , eth " iken `asset=eth` | Geçer (trim + case-insensitive eşleşme) |
+| C-109 | `trade_allowed_coins` null/boş string | Tüm coinler serbest |
+| C-110 | `usd_amount > trade_max_per_order_usd` → 403; `== max` | Sınır değeri **izinli** (yalnız aşım reddedilir) |
+| C-111 | `spent_24h + usd_amount > trade_daily_limit_usd` | 403 "would exceed the 24h limit" |
+| C-112 | `spent_24h + usd_amount == trade_daily_limit_usd` | İzinli (limitin tam dolması red sebebi değil) |
+| C-113 | 24s hesabı: 25 saat önceki filled order, `failed` order, **owner** order ve **başka linkin** orderları | Hiçbiri `spent_today`'e sayılmaz; yalnız aynı linkin son 24 saatteki `filled` delegate orderları sayılır |
+| C-114 | Tüm kontrollerden geçen delegate emri | 200; `TradeOrder`: `status=filled`, `actor=delegate`, `share_link_id` dolu, `symbol={ASSET}USDT`, `exchange_order_id` ve `amount` (executedQty) kaydedilir |
+| C-115 | Exchange API'ye ulaşılamıyor (httpx hatası) | 502 + `TradeOrder` **status=failed** ve `error` alanıyla loglanır (audit'te görünür, 24s limitine sayılmaz) |
+| C-116 | Adapter `ValueError` (ör. emir boyutlandırma için fiyat bulunamadı) | 400; order kaydı oluşmaz |
+| C-117 | Aynı IP'den dakikada 10+ delegate trade isteği | 429 |
+
+### I. Owner Trading
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-118 | `POST /profiles/{id}/trade` başkasının/var olmayan profili | 404 "Profile not found" (owner-trade'de non-owner da 404 alır) |
+| C-119 | Kendi profilinde ilgili borsa için trade key yok | 400 |
+| C-120 | Owner çok büyük emir / whitelist dışı coin / tek yön kısıtı | **Limit kontrolü YOK** — delegate kuralları (yön/whitelist/emir başı/24s) owner'a uygulanmaz, emir borsaya gider |
+| C-121 | Başarılı owner emri | `actor=owner`, `share_link_id=NULL`, `status=filled` |
+| C-122 | Geçersiz `side` / `usd_amount<=0` | 422 |
+| C-123 | Herhangi bir trade yolu (owner/delegate) ile çekim/transfer denemesi | İmkânsız — adapter'larda withdrawal/transfer endpoint'i yok; trade key validasyonu withdrawal iznini zaten reddediyor (kod + validasyon çift bariyer) |
+| C-124 | EDGE: owner trade endpoint'inde rate limit | Yok (mevcut durum) — bilinçli mi, testle/kararla pinlenmeli |
+
+### J. Trade Audit Log
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-125 | `GET /profiles/{id}/trade` kendi profili | 200; en fazla son 50 order, `created_at` desc |
+| C-126 | Profilde hem owner hem delegate orderlar var | İkisi de listede; `actor` alanından ayırt edilir |
+| C-127 | Başkasının profili için trade listesi | 404 |
+| C-128 | Her order kaydı | exchange, symbol, base_asset, side, usd_value, actor, status, created_at (+ varsa amount, exchange_order_id, error) içerir — kim/ne zaman/hangi coin/kaç USD izlenebilir |
+
+### K. P&L (AVCO)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-129 | `GET /profiles/{id}/pnl` var olmayan → 404; başkasının → | 403 |
+| C-130 | Hiç trade yok | 200; `assets=[]`, `total_realized_pnl_usd=0` |
+| C-131 | Yalnız buy'lar (BTC: 1 adet $100 + 1 adet $200) | realized=0; `current_qty=2`, `avg_cost=150`, `total_bought_usd=300`, `buy_count=2` |
+| C-132 | Ardından 1 adet $300'a sell | `realized_pnl_usd=+150` (300−150); `current_qty=1`, `avg_cost=150` kalır, `sell_count=1` |
+| C-133 | Pozisyonun tamamı satılır | `current_qty=0`, `avg_cost=null` |
+| C-134 | Over-sell: CoinHQ 1 adet izlerken 2 adet satılır | Satış izlenen 1 adete **clamp**; qty negatife düşmez; fazlalık P&L'e katılmaz, `total_sold_usd` tam yazılır |
+| C-135 | `failed`/`pending` veya `amount=NULL` orderlar | Hesaba katılmaz (yalnız `filled` + amount dolu) |
+| C-136 | Orderlar karışık sırada eklenmiş | `created_at` asc işlenir (deterministik AVCO); asset'ler alfabetik döner |
+| C-137 | Çoklu asset | `total_realized_pnl_usd` = asset'lerin realized toplamı; UI "yalnız CoinHQ işlemleri — kısmi veri" notunu gösterir |
+
+### L. Snapshots / History
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-138 | `GET /profiles/{id}/history` var olmayan → 404; başkasının → | 403 |
+| C-139 | `days` verilmez → 30; `days=0` veya `days=366` → | 422 (1 ≤ days ≤ 365) |
+| C-140 | Snapshot'lar varken history istenir | Liste **eski→yeni** (`created_at` asc) `{created_at, total_usd}` noktaları |
+| C-141 | `days=7` istenir, 10 gün önceki snapshot var | Cutoff dışındaki nokta dönmez |
+| C-142 | Portföy 1 saat içinde 5 kez fetch edilir (cache'ler düşürülerek) | En fazla 1 yeni snapshot (throttle) |
+| C-143 | Aggregate endpoint'i ve public share view çağrılır | Snapshot **yazılmaz** (yalnız tekil profil portfolio fetch'i yazar) |
+
+### M. Waitlist
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-144 | Yeni email ile `POST /waitlist` | **201** `{id, email, plan, source:"web", created_at}` |
+| C-145 | Aynı email ikinci kez gönderilir | **200** ile mevcut kayıt döner (idempotent; duplicate satır oluşmaz) |
+| C-146 | Geçersiz email ("abc", "a@b") | 422 |
+| C-147 | `" A@B.CoM "` gönderilir | Normalize edilir → `a@b.com`; sonraki `a@b.com` duplicate sayılır |
+| C-148 | Auth'suz istek; `plan` opsiyonel | 201 — JWT gerekmez |
+
+### N. Admin
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-149 | `tier=free` veya `premium` kullanıcı `GET /admin/stats` | 403 "Admin access required" |
+| C-150 | Auth'suz `GET /admin/stats` | 403 (bearer yok) |
+| C-151 | `tier=admin` kullanıcı | 200: `users`, `profiles`, `exchange_keys`, `active_share_links`, `exchanges` (borsa dağılımı), `tiers` (tier dağılımı) |
+| C-152 | Revoked linkler varken stats | `active_share_links` yalnız `is_active=true` olanları sayar |
+
+### O. Tier Limitleri
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-153 | `free` kullanıcı | Max **1 profil** (2.si → 403, C-018) |
+| C-154 | `free` kullanıcı | Profil başına max **2 distinct exchange** (3.sü → 403, C-031); aynı borsanın read_only+trade çifti 1 sayılır |
+| C-155 | `premium` kullanıcı | Profil ve exchange sınırsız (-1) |
+| C-156 | Tanımsız/bozuk tier değeri | Free limitlerine fallback |
+| C-157 | EDGE: `tier=admin` kullanıcı profil/key limiti | `TIER_LIMITS`'te "admin" yok → **free limitlerine düşer** (muhtemel istenmeyen davranış; test pinlemeli / karar) |
+
+### P. Güvenlik (Cross-Cutting)
+
+| ID | Verilen durum | Beklenen sonuç |
+|----|----------------|----------------|
+| C-158 | Tüm endpoint response'ları taranır (keys, portfolio, share, trade, admin) | Hiçbirinde plaintext api_key/api_secret yok |
+| C-159 | Uygulama logları taranır (key ekleme, portfolio fetch, trade) | Plaintext key/secret/JWT loglanmaz; yalnız id'ler ve maskelenmiş key (`abc123...`) |
+| C-160 | `ENCRYPTION_KEY` veya `JWT_SECRET` env'siz başlatma | Uygulama başlamaz (pydantic-settings required field hatası) |
+| C-161 | Key rotasyonu: eski `ENCRYPTION_KEYS` ile şifrelenmiş secret | MultiFernet ile decrypt edilir; yeni yazımlar her zaman primary key ile şifrelenir |
+| C-162 | Üretilen share token'lar | `token_urlsafe(32)` = 256-bit entropi; DB'de unique |
+| C-163 | Yapılandırılmamış origin'den CORS isteği | Reddedilir (yalnız `CORS_ORIGINS` + `FRONTEND_URL`) |
+| C-164 | `read_only` key ile herhangi bir akış | Adapter yalnız GET/okuma çağrıları yapar; emir yerleştirme yolu trade key gerektirir (C-103) |
+| C-165 | Frontend kodu ve network trafiği | API secret yalnız key-ekleme isteğinde frontend→backend gider; backend hiçbir zaman secret'ı frontend'e geri göndermez |
+
+**Toplam: 165 koşul (C-001 … C-165).**
+
+---
+
+## 3. Fake / Demo Data Planı
+
+Testler (pytest fixture'ları) ve UI demo ortamı için gereken veri seti. Exchange
+çağrıları testte **mock'lanır** (respx/monkeypatch ile adapter yanıtları); gerçek
+borsaya asla gidilmez.
+
+### 3.1 Kullanıcılar
+
+| Kullanıcı | tier | Amaç |
+|-----------|------|------|
+| `free@demo.test` (U1) | free | Tier limitleri (1 profil, 2 borsa), limit-dolu durumlar |
+| `premium@demo.test` (U2) | premium | Çoklu profil, trade akışları, share linkler — ana demo kullanıcısı |
+| `admin@demo.test` (U3) | admin | `/admin/stats`; ayrıca C-157 (admin'in profil limiti) |
+| `empty@demo.test` (U4) | free | Hiç profil yok — empty state / onboarding |
+| `attacker@demo.test` (U5) | free | İzolasyon testleri: U1/U2 kaynaklarına 403/404 beklenir |
+
+### 3.2 Profiller ve Key Kombinasyonları
+
+| Profil | Sahip | Key'ler | Amaç |
+|--------|-------|---------|------|
+| P1 "Main" | U1 | binance `read_only` + bybit `read_only` | Free exchange limiti dolu (3. borsa → 403); read-only dashboard |
+| P2 "Trading" | U2 | binance `read_only` + binance `trade` + okx `read_only` | Aynı borsada çift key; owner trade; share+delegate trade kaynağı |
+| P3 "Kraken Spot" | U2 | kraken `trade` (read_only yok) | Yalnız trade key'li profil; trade var/bakiye akışı ayrı |
+| P4 "Boş Profil" | U2 | key yok | "No API keys added yet" durumu; portföy 0 |
+
+Mock bakiyeler (P2/binance): BTC 0.5, ETH 2.0, USDT 1_000, ayrıca Binance'te
+listelenmeyen düşük hacimli 1 coin (CoinGecko fallback testi, C-053) ve 0 bakiyeli
+1 asset (C-081).
+
+### 3.3 Share Link Kombinasyonları (hepsi P2 üzerinde)
+
+| Link | Bayraklar / alanlar | Amaç |
+|------|---------------------|------|
+| SL1 | default'lar (total+alloc açık), expiry yok, label "Muhasebeci" | Temel public view |
+| SL2 | 4 bayrak da **true**, expiry +7 gün, allow_follow=T | Tam görünürlük + expiry yaklaşan |
+| SL3 | 4 bayrak da **false** | Maksimum maskeleme (yalnız asset adları) |
+| SL4 | expires_at **geçmişte** | 410 testi (C-073, C-097) |
+| SL5 | is_active=false (revoked) | 404 testi (C-072) |
+| SL6 | allow_follow=false | Follow 403 (C-090) |
+| SL7 | can_trade=T, direction=both, whitelist "BTC,ETH", max_per_order=500, daily=2000 | Tüm delegate limitlerinin ana senaryosu |
+| SL8 | can_trade=T, direction=**buy**, limitler null | Yön ihlali + limitsiz davranış |
+| SL9 | can_trade=T, direction=**sell** | Ters yön ihlali |
+| SL10 | can_trade=T + expires_at geçmiş | Expired linkle trade → 410 |
+| SL11 | view_count>0, last_viewed_at dolu | Owner panelinde sayaç görünümü |
+
+Not: `can_trade=true` linkler ancak P2'ye trade key eklendikten **sonra**
+oluşturulabilir (C-061) — seed sırası buna göre kurulmalı.
+
+### 3.4 Trade Geçmişi Senaryoları (P2, `trade_orders`)
+
+| # | Kayıt | Amaç |
+|---|-------|------|
+| T1 | buy 0.001 BTC / $100, owner, filled, 10 gün önce | AVCO taban |
+| T2 | buy 0.001 BTC / $200, owner, filled, 8 gün önce | avg_cost=150 senaryosu |
+| T3 | sell 0.001 BTC / $300, owner, filled, 5 gün önce | realized +$150 (C-132) |
+| T4 | buy ETH / $400, **delegate (SL7)**, filled, 2 saat önce | 24s harcama = 400 |
+| T5 | buy ETH / $300, delegate (SL7), **failed**, 1 saat önce | Failed 24s'e sayılmaz (C-113/115) |
+| T6 | buy BTC / $1500, delegate (SL7), filled, **25 saat önce** | Pencere dışı — sayılmaz (C-113) |
+| T7 | sell 5 SOL / $500, owner, filled (SOL hiç alınmamış) | Over-sell clamp (C-134) |
+| T8 | buy DOGE / $50, delegate (**SL8**), filled, 3 saat önce | Link bazlı izolasyon: SL7'nin harcamasına karışmaz |
+
+Bu setle: SL7 için `trade_spent_today_usd=400`; $1601+ yeni delegate emri daily
+limitten 403; tam $1600 emir geçer (C-111/112).
+
+### 3.5 Snapshot / History / Waitlist
+
+- P2 için 30 gün boyunca günde 1 `PortfolioSnapshot` (artan trend: 8.000→12.500 USD) + son 30 dk içinde 1 kayıt (throttle testi C-142).
+- P1 için yalnız 3 nokta (kısa geçmiş grafiği); P4 için hiç (boş grafik durumu).
+- Waitlist: `existing@demo.test` kayıtlı (duplicate→200 testi C-145).
+
+---
+
+## 4. UI Doğrulama Listesi
+
+### /login
+- "Sign in with Google" butonu `{API}/api/v1/auth/google`'a gider.
+- `?error=auth_failed` ile gelindiğinde hata mesajı görünür.
+
+### /auth/callback
+- `?token=...` varsa localStorage'a yazılır → `/dashboard`'a replace; token yoksa `/login?error=auth_failed`.
+
+### /dashboard
+- localStorage'da token yoksa `/login`'e redirect.
+- İlk girişte OnboardingWizard açılır (`onboarding_done` yazılınca bir daha açılmaz).
+- ProfileSwitcher: "Aggregate" + kullanıcının profilleri; seçim değişince veri yeniden yüklenir.
+- PortfolioSummary: toplam USD (aggregate'te `grand_total_usd`); tekil profil görünümünde `cached` göstergesi.
+- PortfolioHistoryChart: yalnız tekil profil seçiliyken dolu (aggregate'te profileId=null); gün aralığı seçimi history endpoint'ini çağırır.
+- AllocationChart (pie) + ExchangeList yan yana; exchange listesinde borsa başına bakiyeler/USD.
+- "Realized P&L" tablosu: asset, qty, avg cost, +yeşil/−kırmızı realized, B/S sayıları; **kısmi veri (yalnız CoinHQ işlemleri)** notu.
+- "Recent Trades": son emirler; delegate/owner ve filled/failed ayırt edilebilir.
+- Hata durumu: kırmızı `role=alert` banner; yüklenirken skeleton; hiç profil yoksa Settings'e link veren empty state.
+
+### /settings
+- Profil CRUD: "Add Profile" modal; free limitte 403 gelince **UpgradeBanner** görünür; silmede ConfirmModal ("cannot be undone").
+- Her profil kartında key listesi: borsa adı + **Read-only / Trade rozeti** + eklenme tarihi; secret hiçbir yerde görüntülenmez; "Remove" onaylı siler.
+- AddKeyModal: 7 borsa seçeneği (binance, binancetr, bybit, okx, coinbase, kraken, gateio), key_type seçimi, borsa API sayfası linkleri; read_only'de write-permission hatası, trade'de withdrawal hatası kullanıcıya aynen gösterilir.
+- Owner TradePanel **yalnız** profilde trade key varsa görünür (yoksa hiç render edilmez); buy/sell toggle, asset, USD tutar; sonuç satırı "Order filled: buy BTC for $X" / hata `role=alert`.
+- ShareLinkManager: profil filtresi; her linkte label/kısaltılmış URL, expiry, **view_count** ("N views") ve last viewed, açık bayrakların özeti ("total, %"), can_trade için amber "Trade" rozeti; Copy URL; "Trade" edit modalı (PATCH — trade key yoksa can_trade açılamaz/400 gösterilir); Revoke onaylı ve liste anında güncellenir; yeni link oluşturulunca tam URL kopyalanabilir kutuda gösterilir.
+
+### /share/[token] (public)
+- Geçersiz/revoked/expired token → "Link not available — expired, revoked, or does not exist" sayfası.
+- Header: allow_follow=true ise FollowButton; "Trading enabled" (amber) veya "Read-only view" rozeti.
+- Toplam kartı: `show_total_value=false` iken "—" + "Total value is hidden by the link owner" notu.
+- Tablo: Amount sütunu yalnız `show_coin_amounts`, Allocation sütunu yalnız `show_allocation_pct` açıkken render edilir; `show_exchange_names=false` iken başlıklar "Exchange xxxxxxxx".
+- `can_trade=true` → DelegateTradePanel: limit özeti (Allowed coins, Max per order, "24h limit: $X (used $Y)"), yön kısıtında tek taraflı buton ("buy only"); backend 403 mesajları (yön/whitelist/limit) panelde aynen görünür; "Withdrawals are never possible" metni.
+- Sıfır bakiyeli asset görünmez; footer "read-only shared view / API secrets are never exposed" + CoinHQ CTA.
+- FollowButton: JWT yoksa "Sign in to follow" akışı; başarıda "Added to your portfolio".
+- EDGE: sayfa ISR ile 300 sn revalidate — revoke/expiry sonrası public sayfa 5 dk'ya kadar stale görünebilir; API yine 404/410 döndüğü için trade/follow çalışmaz (bilinen davranış, testte doğrulanmalı).
+
+### /pricing + WaitlistForm
+- Plan kartları; "Join waitlist" formu: geçersiz email inline hata; başarıda teşekkür durumu; aynı email tekrar gönderilince "already subscribed" davranışı (backend 200 duplicate).

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,29 @@
+# CoinHQ E2E — Demo-mode UI verification
+
+Uçtan uca UI doğrulaması: gerçek tarayıcıda (Playwright) demo-mode backend +
+seed data ile tüm akışları test eder ve `/tmp/e2e-shots` altına screenshot alır.
+
+## Çalıştırma
+
+```bash
+# 1) Backend (demo mode + sqlite + redis)
+cd backend
+export DEMO_MODE=true DATABASE_URL='sqlite+aiosqlite:////tmp/coinhq-demo.db' \
+  REDIS_URL='redis://localhost:6379/0' JWT_SECRET=dev-secret \
+  ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())')"
+uv run python scripts/seed_demo.py > /tmp/seed.json   # kullanıcılar + JWT + share token
+uv run uvicorn app.main:app --port 8000 &
+
+# 2) Frontend
+cd ../frontend && pnpm build && pnpm start -p 3000 &
+
+# 3) E2E
+cd ../e2e && npm install && SEED_JSON=/tmp/seed.json node run-e2e.mjs
+```
+
+Ortam değişkenleri: `FRONTEND_URL` (default http://localhost:3000),
+`SEED_JSON` (default /tmp/seed.json), `SHOT_DIR` (default /tmp/e2e-shots).
+
+Kapsam: login, dashboard (toplam+chart+exchange listesi), settings (profil/key
+rozetleri/share/owner trade), public share (open-trade paneli + limit reddi,
+masked maskeleme, expired/revoked), pricing. 22 kontrol.

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "coinhq-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coinhq-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "playwright": "1.56.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "coinhq-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "End-to-end UI verification against a demo-mode backend (see backend/scripts/seed_demo.py)",
+  "type": "module",
+  "scripts": {
+    "e2e": "node run-e2e.mjs"
+  },
+  "devDependencies": {
+    "playwright": "1.56.1"
+  }
+}

--- a/e2e/run-e2e.mjs
+++ b/e2e/run-e2e.mjs
@@ -58,9 +58,10 @@ const jwt = SEED.users.demo.jwt;
   await page.waitForFunction(() => /\$[0-9][0-9,]*\.[0-9]{2}/.test(document.body.innerText), null, { timeout: 15000 }).catch(() => {});
   await page.waitForTimeout(1500);
   const body = await page.textContent('body');
-  // Demo/Main ~ $37.5k (single demo account; not double-counted across the
-  // profile's read_only + trade keys).
-  check('UI-02', 'dashboard: toplam deger ($3x,xxx) gorunur', /\$3[0-9],[0-9]{3}\.[0-9]{2}/.test(body), (body.match(/\$[0-9][0-9],[0-9]{3}\.[0-9]{2}/) || [''])[0]);
+  // Price-independent: assert a positive formatted total renders (in DEMO_MODE
+  // prices are deterministic so the value is stable, but we don't hard-code it).
+  const totalMatch = body.match(/\$[1-9][0-9,]*\.[0-9]{2}/);
+  check('UI-02', 'dashboard: pozitif toplam deger gorunur', !!totalMatch, totalMatch ? totalMatch[0] : 'YOK');
   check('UI-03', 'dashboard: demo exchange listelenir', /demo/i.test(body));
   check('UI-04', 'dashboard: BTC bakiyesi gorunur', /BTC/.test(body));
   check('UI-05', 'dashboard: allocation chart (svg) render edilir',

--- a/e2e/run-e2e.mjs
+++ b/e2e/run-e2e.mjs
@@ -1,0 +1,179 @@
+/**
+ * CoinHQ E2E UI verification.
+ *
+ * Prereqs (see e2e/README.md):
+ *   - backend running on :8000 in DEMO_MODE with seed_demo.py data
+ *   - frontend (next start) on :3000 with default NEXT_PUBLIC_API_URL
+ *   - SEED_JSON env pointing at seed_demo.py output (default /tmp/seed.json)
+ *
+ * Verifies real user flows in a real browser and saves screenshots to
+ * SHOT_DIR (default /tmp/e2e-shots). Exits non-zero if any check fails.
+ */
+import { chromium } from 'playwright';
+import { readFileSync, mkdirSync } from 'node:fs';
+
+const FRONTEND = process.env.FRONTEND_URL ?? 'http://localhost:3000';
+const SEED = JSON.parse(readFileSync(process.env.SEED_JSON ?? '/tmp/seed.json', 'utf8'));
+const SHOTS = process.env.SHOT_DIR ?? '/tmp/e2e-shots';
+mkdirSync(SHOTS, { recursive: true });
+
+const results = [];
+function check(id, desc, ok, extra = '') {
+  results.push({ id, desc, ok, extra });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${id}  ${desc}${extra ? '  [' + extra + ']' : ''}`);
+}
+
+const browser = await chromium.launch();
+
+async function newPage({ jwt } = {}) {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  if (jwt) {
+    await ctx.addInitScript(([t]) => {
+      localStorage.setItem('token', t);
+      localStorage.setItem('onboarding_done', 'true');
+    }, [jwt]);
+  }
+  return ctx.newPage();
+}
+
+const jwt = SEED.users.demo.jwt;
+
+// ── 1. Login page renders ─────────────────────────────────────────────────────
+{
+  const page = await newPage();
+  await page.goto(`${FRONTEND}/login`, { waitUntil: 'networkidle' });
+  check('UI-01', 'login: Google CTA gorunur',
+    await page.getByText(/Continue with Google/i).isVisible());
+  await page.screenshot({ path: `${SHOTS}/01-login.png` });
+  await page.context().close();
+}
+
+// ── 2. Dashboard: portfolio + chart + PnL + history ──────────────────────────
+{
+  const page = await newPage({ jwt });
+  await page.goto(`${FRONTEND}/dashboard`, { waitUntil: 'networkidle' });
+  // Wait until the portfolio total actually renders (SWR profiles + portfolio
+  // fetch + chart hydration) rather than a fixed sleep.
+  await page.getByText(/Total Portfolio Value/i).waitFor({ timeout: 15000 }).catch(() => {});
+  await page.waitForFunction(() => /\$[0-9][0-9,]*\.[0-9]{2}/.test(document.body.innerText), null, { timeout: 15000 }).catch(() => {});
+  await page.waitForTimeout(1500);
+  const body = await page.textContent('body');
+  // Demo/Main ~ $37.5k (single demo account; not double-counted across the
+  // profile's read_only + trade keys).
+  check('UI-02', 'dashboard: toplam deger ($3x,xxx) gorunur', /\$3[0-9],[0-9]{3}\.[0-9]{2}/.test(body), (body.match(/\$[0-9][0-9],[0-9]{3}\.[0-9]{2}/) || [''])[0]);
+  check('UI-03', 'dashboard: demo exchange listelenir', /demo/i.test(body));
+  check('UI-04', 'dashboard: BTC bakiyesi gorunur', /BTC/.test(body));
+  check('UI-05', 'dashboard: allocation chart (svg) render edilir',
+    (await page.locator('svg').count()) > 0);
+  await page.screenshot({ path: `${SHOTS}/02-dashboard.png`, fullPage: true });
+  await page.context().close();
+}
+
+// ── 3. Settings: profil, key rozetleri, share linkler, owner trade ────────────
+{
+  const page = await newPage({ jwt });
+  await page.goto(`${FRONTEND}/settings`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);
+  const body = await page.textContent('body');
+  check('UI-06', 'settings: profil adi gorunur', /Main Portfolio/.test(body));
+  check('UI-07', 'settings: Read-only + Trade key rozetleri', /Read-only/i.test(body) && /Trade/.test(body));
+  check('UI-08', 'settings: share linkler listelenir (label)', /Muhasebeci/.test(body));
+  check('UI-09', 'settings: owner trade paneli gorunur', /Place (buy|sell) order/i.test(body));
+  await page.screenshot({ path: `${SHOTS}/03-settings.png`, fullPage: true });
+
+  // Owner trade via UI: buy 25 USD BTC
+  try {
+    await page.getByLabel('Asset').first().fill('BTC');
+    await page.getByLabel('USD amount').first().fill('25');
+    await page.getByRole('button', { name: /Place buy order/i }).first().click();
+    await page.waitForTimeout(2500);
+    const after = await page.textContent('body');
+    check('UI-10', 'settings: owner emri UI uzerinden fill olur', /Order filled/i.test(after));
+    await page.screenshot({ path: `${SHOTS}/04-owner-trade.png`, fullPage: true });
+  } catch (e) {
+    check('UI-10', 'settings: owner emri UI uzerinden fill olur', false, String(e).slice(0, 80));
+  }
+  await page.context().close();
+}
+
+// ── 4. Public share (open+trade): panel + limitler + emir + limit reddi ──────
+{
+  const page = await newPage(); // NO auth — public
+  await page.goto(`${FRONTEND}/share/${SEED.share_tokens.open_trade}`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2500);
+  const body = await page.textContent('body');
+  check('UI-11', 'share(open): Trading enabled rozeti', /Trading enabled/i.test(body));
+  check('UI-12', 'share(open): limitler gorunur ($500/order, $2,000/24h, BTC,ETH)',
+    /500/.test(body) && /2,000/.test(body) && /BTC,\s*ETH/i.test(body));
+  check('UI-13', 'share(open): gercek exchange adi gorunur (demo)', /demo/i.test(body));
+  await page.screenshot({ path: `${SHOTS}/05-share-trade.png`, fullPage: true });
+
+  // Valid delegate order via UI: buy 50 USD ETH
+  await page.getByLabel('Asset').fill('ETH');
+  await page.getByLabel('USD amount').fill('50');
+  await page.getByRole('button', { name: /Place buy order/i }).click();
+  await page.waitForTimeout(2500);
+  let after = await page.textContent('body');
+  check('UI-14', 'share(open): delegate emri fill olur', /Order filled/i.test(after));
+  await page.screenshot({ path: `${SHOTS}/06-delegate-trade-ok.png`, fullPage: true });
+
+  // Over-limit order: 600 USD > 500 per-order cap → visible error
+  await page.getByLabel('Asset').fill('BTC');
+  await page.getByLabel('USD amount').fill('600');
+  await page.getByRole('button', { name: /Place buy order/i }).click();
+  await page.waitForTimeout(2500);
+  after = await page.textContent('body');
+  check('UI-15', 'share(open): emir-basi limit asimi UI hatasi verir',
+    /per-order limit/i.test(after) || /exceeds/i.test(after));
+  await page.screenshot({ path: `${SHOTS}/07-delegate-trade-limit.png`, fullPage: true });
+  await page.context().close();
+}
+
+// ── 5. Masked share: maskeleme + read-only ────────────────────────────────────
+{
+  const page = await newPage();
+  await page.goto(`${FRONTEND}/share/${SEED.share_tokens.masked}`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(2000);
+  const body = await page.textContent('body');
+  check('UI-16', 'share(masked): exchange adi maskeli (Exchange xxxx)', /Exchange [0-9a-f]{8}/.test(body));
+  check('UI-17', 'share(masked): gercek exchange adi SIZMAZ', !/>\s*demo\s*</i.test(await page.content()));
+  check('UI-18', 'share(masked): Read-only rozeti, trade paneli YOK',
+    /Read-only view/i.test(body) && !/Place (buy|sell) order/i.test(body));
+  check('UI-19', 'share(masked): follow butonu yok (allow_follow=false)',
+    !/Add to my portfolio/i.test(body));
+  await page.screenshot({ path: `${SHOTS}/08-share-masked.png`, fullPage: true });
+  await page.context().close();
+}
+
+// ── 6. Expired & revoked share sayfalari ──────────────────────────────────────
+{
+  const page = await newPage();
+  await page.goto(`${FRONTEND}/share/${SEED.share_tokens.expired}`, { waitUntil: 'networkidle' });
+  check('UI-20', 'share(expired): "Link not available"',
+    /Link not available|expired/i.test(await page.textContent('body')));
+  await page.screenshot({ path: `${SHOTS}/09-share-expired.png` });
+
+  await page.goto(`${FRONTEND}/share/${SEED.share_tokens.revoked}`, { waitUntil: 'networkidle' });
+  check('UI-21', 'share(revoked): "Link not available"',
+    /Link not available|revoked/i.test(await page.textContent('body')));
+  await page.context().close();
+}
+
+// ── 7. Pricing page ───────────────────────────────────────────────────────────
+{
+  const page = await newPage();
+  await page.goto(`${FRONTEND}/pricing`, { waitUntil: 'networkidle' });
+  check('UI-22', 'pricing: planlar + waitlist formu',
+    /Cloud Premium/.test(await page.textContent('body')));
+  await page.screenshot({ path: `${SHOTS}/10-pricing.png`, fullPage: true });
+  await page.context().close();
+}
+
+await browser.close();
+
+const failed = results.filter(r => !r.ok);
+console.log(`\n==== E2E SONUC: ${results.length - failed.length}/${results.length} PASS ====`);
+if (failed.length) {
+  console.log('FAILED:', failed.map(f => f.id).join(', '));
+  process.exit(1);
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -21,7 +21,7 @@ const PortfolioHistoryChart = dynamic(() => import("@/components/PortfolioHistor
 
 export default function DashboardPage() {
   const router = useRouter();
-  const { profiles = [] } = useProfiles();
+  const { profiles = [], isLoading: profilesLoading } = useProfiles();
   const [selectedProfileId, setSelectedProfileId] = useState<number | "aggregate">("aggregate");
   const [portfolio, setPortfolio] = useState<PortfolioResponse | AggregatePortfolioResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -34,9 +34,12 @@ export default function DashboardPage() {
   }, [router])
 
   useEffect(() => {
+    // Only first-run users (no profiles yet) see onboarding. Returning users
+    // who already have profiles are never forced through it.
+    if (profilesLoading) return
     const done = localStorage.getItem('onboarding_done')
-    if (!done) setShowOnboarding(true)
-  }, [])
+    if (!done && profiles.length === 0) setShowOnboarding(true)
+  }, [profilesLoading, profiles.length])
 
   useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
## Özet
Sistemin uçtan uca **gerçekten çalıştığını** kanıtlamak için tam bir doğrulama altyapısı kurdum ve gerçek app'i çalıştırırken bulduğum 4 hatayı düzelttim. Baştan sona planladım (koşul matrisi), fake/demo data ürettim, hem backend hem UI'ı test ettim, hepsi yeşil olana kadar döngüye devam ettim.

## Yeni — doğrulama altyapısı
- **`backend/app/exchanges/demo.py`** — DEMO_MODE'da açılan "paper" borsa adaptörü: deterministik bakiyeler, marker-driven key validasyonu (`write`→read-only reddi, `withdraw`→trade key reddi), simüle emir dolumu. Ağa çıkmaz.
- **`backend/scripts/seed_demo.py`** — deterministik kullanıcı/profil/key (read_only+trade), 5 share link varyantı (tüm izin + trade-limit kombinasyonları, expired, revoked), trade geçmişi (AVCO P&L), 14 günlük snapshot, waitlist. E2E için JWT'ler ve share token'ları basar.
- **`backend/tests/test_integration_conditions.py`** — gerçek app üzerinden **51 HTTP-level test**: izolasyon/tier/key validasyonu/share izin matrisi/delegate trade limitleri (**24s birikimli** dahil)/owner trade/PnL/history/waitlist/admin.
- **`docs/SYSTEM_TEST_PLAN.md`** — uçtan uca davranış + **165 satırlık koşul matrisi**.
- **`e2e/`** — Playwright ile **22 UI kontrolü** (dashboard, settings, public share trade paneli + limit reddi, maskeleme, expired/revoked) + README.

## Çalıştırırken bulunan ve düzeltilen hatalar
1. **Portföy çift-sayımı (ciddi):** Bir profilde aynı borsanın hem `read_only` hem `trade` key'i olunca bakiyeler iki kez çekilip **toplam 2× görünüyordu** ($75k yerine $37.5k olmalı). Artık borsa başına tek bakiye çekimi (read_only tercih).
2. **Onboarding sihirbazı** profili olan kullanıcıya da açılıyordu → yalnızca hiç profil yokken.
3. **CoinGecko yanlış fiyatlama:** `/coins/list` alfabetik olduğu için major coinler aynı-sembollü dust token'lara düşüyordu (BTC → $0.000005). Major'lar `_CG_ID_OVERRIDES` ile sabitlendi; Binance geo-block olsa bile stablecoin'ler $1.
4. **`database.py`**: `pool_size`/`max_overflow` yalnız postgres'e geçiliyor (SQLite reddediyordu → lokal/demo/test çalışmıyordu).

## Doğrulama (hepsi yeşil)
- Backend: **250 pytest** (51 yeni integration dahil) + `ruff` temiz
- Frontend: **53 vitest** + `lint` + `next build`
- **E2E: 22/22** demo backend'e karşı (dashboard $37,571 — çift-sayım yok)

Ekran görüntüleri `/tmp/e2e-shots` altında üretiliyor; dashboard/settings/share akışları görsel olarak da doğrulandı.

https://claude.ai/code/session_01FMTwJksSySfRzPzhteqoGP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMTwJksSySfRzPzhteqoGP)_